### PR TITLE
Use Docker at Travis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -97,6 +97,7 @@ tramp
 *_archive
 .*
 !.gitignore
+!.travis.*
 *~
 *.bak
 *.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,11 @@
-language: cpp
-compiler:
-    - gcc
-# install additional packages
-# http://docs.travis-ci.com/user/installing-dependencies/
-before_install:
-    - sudo apt-get update -qq
-    - sudo apt-get install -y libboost-dev
-script:
-    - make -f Makefile.cvs
-    - cd build
-    - make -j 4
-    - sudo make install
+sudo: required
+language: bash
+services:
+  - docker
 
+before_install:
+  - docker build -t libyui-image .
+script:
+  # the "libyui-travis" script is included in the base libyui/devel image
+  # see https://github.com/libyui/docker-devel/blob/master/libyui-travis
+  - docker run -it libyui-image libyui-travis

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+# Use the libyui/devel image as the base
+FROM libyui/devel
+
+COPY . /usr/src/app

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/libyui/libyui.svg?branch=master)](https://travis-ci.org/libyui/libyui)
 
-Libyui is a widget abstraction library providing Qt, GTK and Ncurses
+Libyui is a widget abstraction library providing Qt, GTK and ncurses
 frontends. Originally it was developed for [YaST](https://yast.github.io/)
 but it can be used in any independent project.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,32 @@
-![libYUI-boilerplate](http://img191.imageshack.us/img191/9364/libyui.png)
+# LibYUI - The Base Library
 
+[![Build Status](https://travis-ci.org/libyui/libyui.svg?branch=master)](https://travis-ci.org/libyui/libyui)
 
-[![Build Status](https://travis-ci.org/libyui/libyui.png?branch=master)](https://travis-ci.org/libyui/libyui)
+Libyui is a widget abstraction library providing Qt, GTK and Ncurses
+frontends. Originally it was developed for [YaST](https://yast.github.io/)
+but it can be used in any independent project.
+
+This part contains the base abstraction layer which is implemented in several
+target frontends.
+
+### Building
+
+Libyui uses CMake, driven by a slightly complex set of
+[CMakefiles](https://github.com/libyui/libyui/tree/master/buildtools). For
+reproducible builds it is best to use the [libyui-rake](
+https://github.com/libyui/libyui-rake) Ruby gem like the [Jenkins CI](
+https://ci.opensuse.org/view/libyui/) jobs do.
+
+It can be installed from [rubygems.org](https://rubygems.org/gems/libyui-rake/)
+using this command (Ruby needs to be installed in the system):
+
+```
+gem install libyui-rake
+```
+
+Then to build the package run:
+
+```
+rake osc:build
+```
+


### PR DESCRIPTION
This is a similar solution as we use in YaST:

- There is a shared [libyui/devel](https://hub.docker.com/r/libyui/devel/) Docker image
- It is developed at the [libyui/docker-devel](https://github.com/libyui/docker-devel) GitHub repository
- There is a [shared script](https://github.com/libyui/docker-devel/blob/master/libyui-travis) to run the build a Travis