### PR TITLE
Avoid variable expansion related CMake warnings (CMP0053)

### DIFF
--- a/buildtools/CMakeLists.common
+++ b/buildtools/CMakeLists.common
@@ -1,5 +1,11 @@
 CMAKE_MINIMUM_REQUIRED( VERSION 2.8 )
 
+# Avoid 6000 lines(!) of warnings for cmake-bundled(!) files
+# CMP0053: Simplify variable reference and escape sequence evaluation
+if( POLICY CMP0053 )
+  cmake_policy( SET CMP0053 OLD )
+endif()
+
 INCLUDE( "${CMAKE_SOURCE_DIR}/PROJECTINFO.cmake" )
 
 SET( BUILDTOOLS_DIR "buildtools/" )


### PR DESCRIPTION
CMP0053: Simplify variable reference and escape sequence evaluation