### PR TITLE
Bump SO-Name and Version

### DIFF
--- a/VERSION.cmake
+++ b/VERSION.cmake
@@ -1,12 +1,12 @@
 SET( VERSION_MAJOR "3")
-SET( VERSION_MINOR "2" )
-SET( VERSION_PATCH "9" )
+SET( VERSION_MINOR "3" )
+SET( VERSION_PATCH "0" )
 SET( VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}${GIT_SHA1_VERSION}" )
 
 ##### This is need for the libyui core, ONLY.
 ##### These will be overridden from exports in LibyuiConfig.cmake
 # must also adjust "Requires: yui_backend = SONAME_MAJOR" in libyui.spec.in
-SET( SONAME_MAJOR "7" )
+SET( SONAME_MAJOR "8" )
 SET( SONAME_MINOR "0" )
 SET( SONAME_PATCH "0" )
 SET( SONAME "${SONAME_MAJOR}.${SONAME_MINOR}.${SONAME_PATCH}" )

--- a/package/libyui-doc.spec
+++ b/package/libyui-doc.spec
@@ -17,10 +17,10 @@
 
 
 %define parent libyui
-%define so_version 7
+%define so_version 8
 
 Name:           %{parent}-doc
-Version:        3.2.9
+Version:        3.3.0
 Release:        0
 Source:         %{parent}-%{version}.tar.bz2
 

--- a/package/libyui.changes
+++ b/package/libyui.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Apr 10 23:54:00 UTC 2017 - besser82@fedoraproject.org
+
+- Last version introduced a new symbol, thus so-name and minor
+  version must be bumped
+- 3.3.0
+
+-------------------------------------------------------------------
 Fri Nov 25 09:22:14 UTC 2016 - jreidinger@suse.com
 
 - implement shortcut conflicts resolver for menu buttons

--- a/package/libyui.spec
+++ b/package/libyui.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           libyui
-Version:        3.2.9
+Version:        3.3.0
 Release:        0
 Source:         %{name}-%{version}.tar.bz2
 


### PR DESCRIPTION
Last version introduced a new symbol, thus so-name and minor version must be bumped