### PR TITLE
Added code coverage support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,7 @@ Makefile.in
 # CMake
 CMakeCache.txt
 CMakeFiles
-CMakeLists.txt
+/CMakeLists.txt
 Makefile
 cmake_install.cmake
 install_manifest.txt
@@ -115,5 +115,7 @@ tmp
 # Examples
 /examples/*
 # but keep sources and cmake
-!/examples/CMakeList.txt
 !/examples/*.cc
+
+# Code coverage
+/coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ before_install:
 script:
   # the "libyui-travis" script is included in the base libyui/devel image
   # see https://github.com/libyui/docker-devel/blob/master/libyui-travis
-  - docker run -it libyui-image libyui-travis
+  - docker run -it -e COVERALLS_TOKEN="$COVERALLS_TOKEN" libyui-image libyui-travis

--- a/Makefile.cvs
+++ b/Makefile.cvs
@@ -2,6 +2,11 @@
 # Makefile.cvs
 #
 
+# enable coverage if $COVERAGE is set to 1
+ifeq ($(COVERAGE), 1)
+EXTRA_PARAMS := -DENABLE_CODE_COVERAGE=ON
+endif
+
 all: configure
 
 configure: clean
@@ -9,7 +14,7 @@ configure: clean
 	mkdir build ; \
 	cd build ; \
 	cmake .. \
-	-DCMAKE_BUILD_TYPE=RELEASE
+	-DCMAKE_BUILD_TYPE=RELEASE $(EXTRA_PARAMS)
 
 install: configure
 	cd build ; \

--- a/PROJECTINFO.cmake
+++ b/PROJECTINFO.cmake
@@ -4,7 +4,7 @@ SET( BASELIB		"yui" )		# don't change this
 
 ##### MAKE ALL NEEDED CHANGES HERE #####
 
-SET( SUBDIRS		src examples )
+SET( SUBDIRS		src examples tests )
 SET( LIB_DEPS		Boost )
 SET( LIB_LINKER		dl pthread )
 SET( EXTRA_INCLUDES     )         # set include-dir which are not picked by CMake automagically here.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # LibYUI - The Base Library
 
 [![Build Status](https://travis-ci.org/libyui/libyui.svg?branch=master)](https://travis-ci.org/libyui/libyui)
+[![Coverage Status](
+https://coveralls.io/repos/github/libyui/libyui/badge.svg?branch=master)](
+https://coveralls.io/github/libyui/libyui?branch=master)
 
 Libyui is a widget abstraction library providing Qt, GTK and ncurses
 frontends. Originally it was developed for [YaST](https://yast.github.io/)

--- a/buildtools/LibyuiCommon.cmake
+++ b/buildtools/LibyuiCommon.cmake
@@ -58,6 +58,8 @@ MACRO( SET_OPTIONS )		# setup configurable options
   OPTION( ENABLE_WERROR "Enable the -Werror compiler-flag?" ON )
   OPTION( RESPECT_FLAGS "Shall I respect the system c/ldflags?" OFF )
   OPTION( INSTALL_DOCS "Shall \"make install\" install the docs?" OFF )
+  OPTION( ENABLE_TESTS "Enable tests?" ON)
+  OPTION( ENABLE_CODE_COVERAGE "Enable code coverage report?" OFF)
 
 ENDMACRO( SET_OPTIONS )
 
@@ -115,6 +117,64 @@ MACRO( SET_BUILD_FLAGS )	# setup compiler-flags depending on CMAKE_BUILD_TYPE
          FORCE
     )
   ENDIF( NOT BUILD_TYPE_PASSED )
+
+  IF ( ENABLE_TESTS OR ENABLE_CODE_COVERAGE)
+    ENABLE_TESTING()
+    # add a wrapper "tests" target, the builtin "test" cannot be extended :-(
+    ADD_CUSTOM_TARGET(tests
+      make
+      COMMAND make test
+    )
+  ENDIF ( ENABLE_TESTS OR ENABLE_CODE_COVERAGE)
+
+  IF ( ENABLE_CODE_COVERAGE )
+    # pass the coverage options to GCC
+    ADD_DEFINITIONS(--coverage)
+    LINK_LIBRARIES(--coverage)
+    # force debug build to not optimize the code, the optimized out code
+    # might be reported as not covered
+    SET( CMAKE_BUILD_TYPE DEBUG CACHE
+         STRING "set to DEBUG"
+         FORCE
+    )
+
+    FIND_PROGRAM( LCOV_PATH lcov )
+    FIND_PROGRAM( GENHTML_PATH genhtml )
+
+    IF(LCOV_PATH AND GENHTML_PATH)
+      # save the coverage data to coverage/ subdir
+      SET(COVERAGE_DATA "coverage/coverage.info")
+      ADD_CUSTOM_TARGET(coverage
+        # remove the previous coverage data
+        rm -rf coverage/*
+        COMMAND mkdir -p coverage
+        # collect the coverage data, ignore external files (/usr/include/...), ignore tests
+        COMMAND ${LCOV_PATH} --no-external --exclude '*/tests/*' -o ${COVERAGE_DATA} -c -d . -q
+        # generate the HTML coverage report
+        COMMAND ${GENHTML_PATH} -o coverage --legend --title "libyui code coverage" -q ${COVERAGE_DATA}
+        # print the coverage summary on the terminal
+        COMMAND ${LCOV_PATH} --list ${COVERAGE_DATA}
+        WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+        COMMENT "Generating the code coverage report..."
+      )
+      # display a comment when finished
+      ADD_CUSTOM_COMMAND(TARGET coverage POST_BUILD
+        COMMAND ;
+        COMMENT "Code coverage gerated to ./coverage/index.html file."
+      )
+      # automatically collect code coverage after "tests" target is finished
+      ADD_CUSTOM_COMMAND(TARGET tests POST_BUILD
+        COMMAND make coverage
+      )
+    ELSE(LCOV_PATH AND GENHTML_PATH)
+      MESSAGE(WARNING "lcov is not installed, code coverage report will not be generated.")
+      ADD_CUSTOM_TARGET(coverage
+        echo "Install the lcov package."
+        COMMAND ;
+        COMMENT "WARNING: lcov is not installed, cannot generate the code coverage report."
+      )
+    ENDIF(LCOV_PATH AND GENHTML_PATH)
+  ENDIF ( ENABLE_CODE_COVERAGE )
 
   SET( CMAKE_CXX_FLAGS_DEBUG	"-O0 -g3" )
   SET( CMAKE_C_FLAGS_DEBUG 	"-O0 -g3" )
@@ -566,6 +626,8 @@ MACRO( SUMMARY )		# prints a brief summary to stdout
   ENDIF( ENABLE_DEBUG OR ${CMAKE_BUILD_TYPE} STREQUAL "RELWITHDEBINFO" OR ${CMAKE_BUILD_TYPE} STREQUAL "DEBUG" )
   MESSAGE( STATUS "     Build a static library, too:           ${ENABLE_STATIC}" )
   MESSAGE( STATUS "     Build the examples, too:               ${ENABLE_EXAMPLES}" )
+  MESSAGE( STATUS "     Build the tests, too:                  ${ENABLE_TESTS}" )
+  MESSAGE( STATUS "     Generate test code coverage:           ${ENABLE_CODE_COVERAGE}" )
   MESSAGE( STATUS "" )
   IF( INSTALL_DOCS AND DOXYGEN_FOUND )
     MESSAGE( STATUS "RUN `make docs` BEFORE `make install` !!!" )
@@ -723,3 +785,25 @@ MACRO( PROCESS_EXAMPLES )
   )
 
 ENDMACRO( PROCESS_EXAMPLES )
+
+
+
+MACRO( PROCESS_TESTS )
+
+  FIND_PACKAGE(Boost COMPONENTS unit_test_framework REQUIRED)
+  INCLUDE_DIRECTORIES(${Boost_INCLUDE_DIRS} ../src ${CMAKE_INCLUDE_PATH} )
+  ADD_DEFINITIONS(-DBOOST_TEST_DYN_LINK -DTESTS_SRC_DIR="${CMAKE_CURRENT_SOURCE_DIR}" )
+
+  # expect the tests in *_test.cc files
+  FILE(GLOB unit_tests "*_test.cc")
+  FOREACH(unit_test ${unit_tests})
+    # strip the .cc suffix
+    GET_FILENAME_COMPONENT(unit_test_bin ${unit_test} NAME_WE)
+    # build the test executable
+    ADD_EXECUTABLE(${unit_test_bin} ${unit_test})
+    TARGET_LINK_LIBRARIES (${unit_test_bin} ${BASELIB} ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY} )
+    # add it to the test suite
+    ADD_TEST(NAME ${unit_test_bin} COMMAND ${unit_test_bin})
+  ENDFOREACH(unit_test)
+
+ENDMACRO( PROCESS_TESTS )

--- a/buildtools/LibyuiCommon.cmake
+++ b/buildtools/LibyuiCommon.cmake
@@ -122,8 +122,8 @@ MACRO( SET_BUILD_FLAGS )	# setup compiler-flags depending on CMAKE_BUILD_TYPE
     ENABLE_TESTING()
     # add a wrapper "tests" target, the builtin "test" cannot be extended :-(
     ADD_CUSTOM_TARGET(tests
-      make
-      COMMAND make test
+      $(MAKE)
+      COMMAND $(MAKE) test
     )
   ENDIF ( ENABLE_TESTS OR ENABLE_CODE_COVERAGE)
 
@@ -164,7 +164,7 @@ MACRO( SET_BUILD_FLAGS )	# setup compiler-flags depending on CMAKE_BUILD_TYPE
       )
       # automatically collect code coverage after "tests" target is finished
       ADD_CUSTOM_COMMAND(TARGET tests POST_BUILD
-        COMMAND make coverage
+        COMMAND $(MAKE) coverage
       )
     ELSE(LCOV_PATH AND GENHTML_PATH)
       MESSAGE(WARNING "lcov is not installed, code coverage report will not be generated.")

--- a/buildtools/LibyuiCommon.cmake
+++ b/buildtools/LibyuiCommon.cmake
@@ -167,12 +167,7 @@ MACRO( SET_BUILD_FLAGS )	# setup compiler-flags depending on CMAKE_BUILD_TYPE
         COMMAND $(MAKE) coverage
       )
     ELSE(LCOV_PATH AND GENHTML_PATH)
-      MESSAGE(WARNING "lcov is not installed, code coverage report will not be generated.")
-      ADD_CUSTOM_TARGET(coverage
-        echo "Install the lcov package."
-        COMMAND ;
-        COMMENT "WARNING: lcov is not installed, cannot generate the code coverage report."
-      )
+      MESSAGE(FATAL_ERROR "lcov is not installed, code coverage report cannot be generated.")
     ENDIF(LCOV_PATH AND GENHTML_PATH)
   ENDIF ( ENABLE_CODE_COVERAGE )
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,1 @@
+PROCESS_TESTS()

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,36 @@
+
+# Unit Tests
+
+This directory contains unit tests.
+
+The unit tests are enabled by default, if you want to disable them (not
+recommended!) then use the `-DENABLE_TESTS=OFF` cmake option.
+
+
+## Writing Tests
+
+- The test files should end with `_test.cc` suffix.
+- Use the boost test framework, see the [documentation](
+https://www.boost.org/doc/libs/release/libs/test/doc/html/index.html).
+
+
+## Running the Tests
+
+Run `make test`. If some some test fails and you need to get more details
+then directly run the test binary from `build/tests` directory, it will print
+the details on the console.
+
+
+## Code Coverage
+
+The code coverage reporting can be enabled using the `-DENABLE_CODE_COVERAGE=ON`
+cmake option or using the `make -f Makefile.cvs COVERAGE=1` initial call.
+The `lcov` package needs to be installed.
+
+To print the code coverage run `make`, `make test` and `make coverage`.
+There is an additional all-in-one target which build the sources, runs the tests
+and prints the code coverage - simply run `make tests`.
+
+The code coverage summary will be displayed on the console. If you need more
+details (e.g. which lines are covered) then open the `coverage/index.html`
+file in a web browser.

--- a/tests/test_test.cc
+++ b/tests/test_test.cc
@@ -1,0 +1,9 @@
+
+#define BOOST_TEST_MODULE trivial_test
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_CASE( just_a_trivial_test_case )
+{
+    BOOST_CHECK_EQUAL( true, true );
+}
+


### PR DESCRIPTION
- No test included (yet), this is just enabling the support, I'll add a real test later with a related code change.

I have added a new  `make tests` target which builds the sources, runs the tests
and prints the code coverage. But I'm not sure if it is a good name, it might be confusing with the default `make test` which just runs the tests. Any suggestions?

I want to run the code coverage automatically, unfortunately the default `test` make target cannot be extended, cmake prints some error... :worried: 