### PR TITLE
Improve the FSize class to handle big values (bsc#991090)

### DIFF
--- a/VERSION.cmake
+++ b/VERSION.cmake
@@ -1,6 +1,6 @@
 SET( VERSION_MAJOR "3")
 SET( VERSION_MINOR "4" )
-SET( VERSION_PATCH "1" )
+SET( VERSION_PATCH "2" )
 SET( VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}${GIT_SHA1_VERSION}" )
 
 ##### This is need for the libyui core, ONLY.
@@ -8,7 +8,7 @@ SET( VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}${GIT_SHA1_VERSI
 # Currently you must also change so_version in libyui.spec
 # *and also in **all** other* libyui-*.spec files in the other repositories.
 # Yes, such a design is suboptimal.
-SET( SONAME_MAJOR "8" )
-SET( SONAME_MINOR "1" )
+SET( SONAME_MAJOR "9" )
+SET( SONAME_MINOR "0" )
 SET( SONAME_PATCH "0" )
 SET( SONAME "${SONAME_MAJOR}.${SONAME_MINOR}.${SONAME_PATCH}" )

--- a/package/libyui-doc.spec
+++ b/package/libyui-doc.spec
@@ -17,10 +17,10 @@
 
 
 %define parent libyui
-%define so_version 8
+%define so_version 9
 
 Name:           %{parent}-doc
-Version:        3.4.1
+Version:        3.4.2
 Release:        0
 Source:         %{parent}-%{version}.tar.bz2
 

--- a/package/libyui.changes
+++ b/package/libyui.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu Jul 26 07:45:20 UTC 2018 - lslezak@suse.cz
+
+- Improved the FSize class to handle arbitrary sizes, use the boost
+  multiprecision library instead of `long long` which overflows for
+  values > 8EiB (bsc#991090)
+- 3.4.2
+
+-------------------------------------------------------------------
 Wed May  9 07:34:16 UTC 2018 - mliska@suse.cz
 
 - Fix GCC 8 warning: -Werror=catch-value (boo#1084636).

--- a/package/libyui.spec
+++ b/package/libyui.spec
@@ -16,11 +16,11 @@
 #
 
 Name:           libyui
-Version:        3.4.1
+Version:        3.4.2
 Release:        0
 Source:         %{name}-%{version}.tar.bz2
 
-%define so_version 8
+%define so_version 9
 %define bin_name %{name}%{so_version}
 
 # optionally build with code coverage reporting,

--- a/src/FSize.h
+++ b/src/FSize.h
@@ -1,5 +1,6 @@
 /*
   Copyright (C) 2000-2012 Novell, Inc
+  Copyright (C) 2018 SUSE LLC
   This library is free software; you can redistribute it and/or modify
   it under the terms of the GNU Lesser General Public License as
   published by the Free Software Foundation; either version 2.1 of the
@@ -21,7 +22,7 @@
   Author:     Michael Andres <ma@suse.de>
   Maintainer: Michael Andres <ma@suse.de>
 
-  Purpose: Store and operate on (file/package/partition) sizes (long long).
+  Purpose: Store and operate on (file/package/partition) sizes.
 
 /-*/
 #ifndef _FSize_h_
@@ -30,45 +31,65 @@
 #include <iosfwd>
 #include <string>
 
+// arbitrary precision integer
+#include <boost/multiprecision/cpp_int.hpp>
+// generate additional operators via the boost templates
+#include <boost/operators.hpp>
+
 //
 //	CLASS NAME : FSize
 //
 /**
- * Store and operate on (file/package/partition) sizes (long long).
+ * Store and operate on (file/package/partition) sizes.
  **/
-class FSize {
+class FSize :
+    // generate > / * + - <= => !== operators
+    boost::ordered_field_operators<FSize>,
+    // generate postfix ++ --
+    boost::unit_steppable<FSize>
+  {
 
   public:
 
     /**
      * The Units
      **/
-    enum Unit { B = 0, K, M, G, T };
+    enum class Unit { B, K, M, G, T, P, E, Z, Y };
 
   private:
 
     /**
-     * The size in Byte
+     * The size (in bytes)
+     * @see https://www.boost.org/doc/libs/release/libs/multiprecision/doc/html/index.html
      **/
-    long long _size;
+    boost::multiprecision::cpp_int _size;
 
   public:
 
-    static const long long KB = 1024;
-    static const long long MB = 1024 * KB;
-    static const long long GB = 1024 * MB;
-    static const long long TB = 1024 * GB;
+    static const boost::multiprecision::cpp_int KB;
+    static const boost::multiprecision::cpp_int MB;
+    static const boost::multiprecision::cpp_int GB;
+    static const boost::multiprecision::cpp_int TB;
+    static const boost::multiprecision::cpp_int PB;
+    static const boost::multiprecision::cpp_int EB;
+    // these do not fit long long anymore!
+    static const boost::multiprecision::cpp_int ZB;
+    static const boost::multiprecision::cpp_int YB;
 
     /**
-     * Return ammount of Byte in Unit.
+     * Return ammount of bytes in Unit.
      **/
-    static long long factor( const Unit unit_r ) {
+    static boost::multiprecision::cpp_int factor( const Unit unit_r ) {
       switch ( unit_r ) {
-      case T: return TB;
-      case G: return GB;
-      case M: return MB;
-      case K: return KB;
-      case B: break;
+      case Unit::Y: return YB;
+      case Unit::Z: return ZB;
+      case Unit::E: return EB;
+      case Unit::P: return PB;
+      case Unit::T: return TB;
+      case Unit::G: return GB;
+      case Unit::M: return MB;
+      case Unit::K: return KB;
+      case Unit::B: break;
       }
       return 1;
     }
@@ -78,11 +99,15 @@ class FSize {
      **/
     static const char * unit( const Unit unit_r ) {
       switch ( unit_r ) {
-      case T: return "TB";
-      case G: return "GB";
-      case M: return "MB";
-      case K: return "kB";
-      case B: break;
+      case Unit::Y: return "YiB";
+      case Unit::Z: return "ZiB";
+      case Unit::E: return "EiB";
+      case Unit::P: return "PiB";
+      case Unit::T: return "TiB";
+      case Unit::G: return "GiB";
+      case Unit::M: return "MiB";
+      case Unit::K: return "KiB";
+      case Unit::B: break;
       }
       return "B";
     }
@@ -90,55 +115,71 @@ class FSize {
   public:
 
     /**
-     * Construct from size in Byte.
+     * Construct from size in certain unit.
+     * E.g. <code>FSize( 1, FSize::Unit::K )<code> makes 1024 Byte.
      **/
-    FSize( const long long size_r = 0 )
+    FSize( const boost::multiprecision::cpp_int &size_r = 0, const Unit unit_r = Unit::B)
+      : _size( boost::multiprecision::cpp_int(size_r) * factor( unit_r ) )
+    {}
+
+    /**
+     * Construct from size in Byte.
+     * @param size_r the initial value
+     **/
+    FSize( double size_r )
       : _size( size_r )
     {}
 
     /**
-     * Construct from size in certain unit.
-     * E.g. <code>FSize( 1, FSize::K )<code> makes 1024 Byte.
-     **/
-    FSize( const long long size_r, const Unit unit_r )
-      : _size( size_r * factor( unit_r ) )
-    {}
-
-    /**
       Construct from string containing a number in given unit.
+      * @param sizeStr input string - must contain *only* numbers
+      * @param unit_r  optional unit, bytes by default
+      * @throws std::runtime_error if the string contains any non numeric characters,
+      *   even a trailing white space!
     */
-    FSize( const std::string &sizeStr, const Unit unit_r = B );
+    FSize( const std::string &sizeStr, const Unit unit_r = Unit::B );
 
     /**
-     * Conversion to long long
+     * Conversions to native data types - only explicit as it might overflow
+     * If the value is out of range then the behavior depends on the boost version
+     *   - 1.67 - the min/max values for the corresponding type are returned
+     *   - 1.66 - returns just the lower bits
      **/
-    operator long long() const { return _size; }
+    explicit operator long long() const { return static_cast<long long>(_size); }
+    explicit operator int() const { return static_cast<int>(_size); }
+    explicit operator double() const { return static_cast<double>(_size); }
 
-    FSize & operator+=( const long long rhs ) { _size += rhs; return *this; }
-    FSize & operator-=( const long long rhs ) { _size -= rhs; return *this; }
-    FSize & operator*=( const long long rhs ) { _size *= rhs; return *this; }
-    FSize & operator/=( const long long rhs ) { _size /= rhs; return *this; }
+    operator boost::multiprecision::cpp_int() const { return _size; }
+    boost::multiprecision::cpp_int in_unit(const Unit unit_r) const { return _size / factor( unit_r ); }
 
-    FSize & operator++(/*prefix*/) { _size += 1; return *this; }
-    FSize & operator--(/*prefix*/) { _size -= 1; return *this; }
+    // unary minus
+    FSize operator-() const { return FSize(-_size); }
+    FSize & operator+=( const FSize &rhs ) { _size += boost::multiprecision::cpp_int(rhs); return *this; }
+    FSize & operator-=( const FSize &rhs ) { _size -= boost::multiprecision::cpp_int(rhs); return *this; }
+    FSize & operator*=( const FSize &rhs ) { _size *= boost::multiprecision::cpp_int(rhs); return *this; }
+    FSize & operator/=( const FSize &rhs ) { _size /= boost::multiprecision::cpp_int(rhs); return *this; }
 
-    FSize operator++(int/*postfix*/) { return _size++; }
-    FSize operator--(int/*postfix*/) { return _size--; }
+    bool operator<( const FSize &rhs ) const { return _size < boost::multiprecision::cpp_int(rhs); }
+    bool operator==( const FSize &rhs ) const { return _size == boost::multiprecision::cpp_int(rhs); }
+
+    // ++operator (the prefix variant)
+    FSize & operator++() { _size += 1; return *this; }
+    // --operator (the prefix variant)
+    FSize & operator--() { _size -= 1; return *this; }
 
     /**
      * Adjust size to multiple of <code>blocksize_r</code>
      **/
-    FSize & fillBlock( FSize blocksize_r = KB );
+    FSize & fillBlock( FSize blocksize_r = boost::multiprecision::cpp_int(KB) );
 
     /**
-     * Return size adjusted to multiple of <code>blocksize_r</code>
+     * Return a new size adjusted to multiple of <code>blocksize_r</code>
      **/
-    FSize fullBlock( FSize blocksize_r = KB ) const { FSize ret( _size ); return ret.fillBlock(  blocksize_r );	}
-
-    /**
-     * Return size in Unit ( not rounded )
-     **/
-    long long operator()( const Unit unit_r ) const { return _size / factor( unit_r ); }
+    FSize fullBlock( FSize blocksize_r = boost::multiprecision::cpp_int(KB) ) const
+    {
+        FSize ret( _size );
+        return ret.fillBlock(  blocksize_r );
+    }
 
     /**
      * Return the best unit for string representation.
@@ -176,5 +217,8 @@ class FSize {
     std::string asString() const;
 };
 
+// stream operators
+std::ostream& operator<<(std::ostream &ostr, const FSize&);
+std::ostream& operator<<(std::ostream &ostr, const FSize::Unit);
 
 #endif // _FSize_h_

--- a/tests/FSize_test.cc
+++ b/tests/FSize_test.cc
@@ -1,0 +1,402 @@
+
+#define BOOST_TEST_MODULE FSize_tests
+#include <boost/test/unit_test.hpp>
+#include <boost/version.hpp>
+
+#include <limits>
+#include <sstream>
+
+#include "FSize.h"
+
+using boost::multiprecision::cpp_int;
+
+// decrease the log level to warnings
+struct LogWarnings {
+  // global initialization before running any test
+  void setup() {
+      boost::unit_test::unit_test_log.set_threshold_level( boost::unit_test::log_warnings );
+  }
+  // cleanup after all tests are finished
+  void teardown() { }
+};
+
+BOOST_TEST_GLOBAL_FIXTURE( LogWarnings );
+
+BOOST_AUTO_TEST_CASE( constructor )
+{
+    // check the default constructor
+    FSize fsize;
+    BOOST_CHECK_EQUAL( fsize, 0 );
+
+    // check an int parameter
+    FSize fsize_int(42);
+    BOOST_CHECK_EQUAL( fsize_int, 42 );
+
+    // check a long long parameter
+    FSize fsize_long(1LL << 40);
+    BOOST_CHECK_EQUAL( fsize_long, 1LL << 40);
+
+    // check a double parameter
+    FSize fsize_double(42.0);
+    BOOST_CHECK_EQUAL( fsize_double, 42.0);
+    // the decimal part is ignored
+    BOOST_CHECK_EQUAL( fsize_double, FSize(42.1));
+    BOOST_CHECK_EQUAL( fsize_double, FSize(42.5));
+    BOOST_CHECK_EQUAL( fsize_double, FSize(42.9));
+
+    // check negative number
+    FSize fsize_int_neg(-42);
+    BOOST_CHECK_EQUAL( fsize_int_neg, -42 );
+
+    // create with units
+    long long u = 1;
+    BOOST_CHECK_EQUAL( FSize(1, FSize::Unit::B), 1);
+    BOOST_CHECK_EQUAL( FSize(1, FSize::Unit::K), u *= 1024);
+    BOOST_CHECK_EQUAL( FSize(1, FSize::Unit::M), u *= 1024);
+    BOOST_CHECK_EQUAL( FSize(1, FSize::Unit::G), u *= 1024);
+    BOOST_CHECK_EQUAL( FSize(1, FSize::Unit::T), u *= 1024);
+    BOOST_CHECK_EQUAL( FSize(1, FSize::Unit::P), u *= 1024);
+    BOOST_CHECK_EQUAL( FSize(1, FSize::Unit::E), u *= 1024);
+    // too much for a long long...
+    BOOST_CHECK_EQUAL( FSize(1, FSize::Unit::Z), cpp_int(1) << 70);
+    BOOST_CHECK_EQUAL( FSize(1, FSize::Unit::Y), cpp_int(1) << 80);
+
+    BOOST_CHECK_EQUAL( FSize(128, FSize::Unit::K), 128 * 1024);
+    BOOST_CHECK_EQUAL( FSize(-128, FSize::Unit::K), -(128 * 1024));
+
+    // from string
+    BOOST_CHECK_EQUAL( FSize("128", FSize::Unit::K), 128 * 1024);
+    BOOST_CHECK_EQUAL( FSize("-128", FSize::Unit::K), -128 * 1024);
+    BOOST_CHECK_EQUAL( FSize("856", FSize::Unit::M), 856 * 1024 * 1024);
+
+    // throws std::runtime_error exception for invalid data!!
+    BOOST_CHECK_THROW( FSize("72.89", FSize::Unit::K), std::runtime_error);
+    BOOST_CHECK_THROW( FSize(" 72  ", FSize::Unit::K), std::runtime_error);
+    BOOST_CHECK_THROW( FSize("72asdf", FSize::Unit::K), std::runtime_error);
+}
+
+BOOST_AUTO_TEST_CASE( comparing_positive )
+{
+    FSize fsize(42);
+    BOOST_CHECK_EQUAL( fsize == 42, true );
+    BOOST_CHECK_EQUAL( fsize != 42, false );
+
+    BOOST_CHECK_EQUAL( fsize > 0, true );
+    BOOST_CHECK_EQUAL( fsize > 10, true );
+    BOOST_CHECK_EQUAL( fsize > 42, false );
+    BOOST_CHECK_EQUAL( fsize > -42, true );
+
+    BOOST_CHECK_EQUAL( fsize >= 0, true );
+    BOOST_CHECK_EQUAL( fsize >= 10, true );
+    BOOST_CHECK_EQUAL( fsize >= 42, true );
+    BOOST_CHECK_EQUAL( fsize >= -42, true );
+
+    BOOST_CHECK_EQUAL( fsize < 0, false );
+    BOOST_CHECK_EQUAL( fsize < 10, false );
+    BOOST_CHECK_EQUAL( fsize < 42, false );
+    BOOST_CHECK_EQUAL( fsize < -42, false );
+
+    BOOST_CHECK_EQUAL( fsize < 0, false );
+    BOOST_CHECK_EQUAL( fsize < 10, false );
+    BOOST_CHECK_EQUAL( fsize <= 42, true );
+    BOOST_CHECK_EQUAL( fsize <= -42, false );
+}
+
+BOOST_AUTO_TEST_CASE( comparing_negative )
+{
+    FSize fsize(-42);
+    BOOST_CHECK_EQUAL( fsize == -42, true );
+    BOOST_CHECK_EQUAL( fsize != -42, false );
+
+    BOOST_CHECK_EQUAL( fsize > 0, false );
+    BOOST_CHECK_EQUAL( fsize > 10, false );
+    BOOST_CHECK_EQUAL( fsize > -42, false );
+    BOOST_CHECK_EQUAL( fsize > -52, true );
+
+    BOOST_CHECK_EQUAL( fsize >= 0, false );
+    BOOST_CHECK_EQUAL( fsize >= 10, false );
+    BOOST_CHECK_EQUAL( fsize >= -42, true );
+    BOOST_CHECK_EQUAL( fsize >= -52, true );
+
+    BOOST_CHECK_EQUAL( fsize < 0, true );
+    BOOST_CHECK_EQUAL( fsize < 10, true );
+    BOOST_CHECK_EQUAL( fsize < 42, true );
+    BOOST_CHECK_EQUAL( fsize < -42, false );
+    BOOST_CHECK_EQUAL( fsize < -52, false );
+
+    BOOST_CHECK_EQUAL( fsize < 0, true );
+    BOOST_CHECK_EQUAL( fsize < 10, true );
+    BOOST_CHECK_EQUAL( fsize <= 42, true );
+    BOOST_CHECK_EQUAL( fsize <= -42, true );
+    BOOST_CHECK_EQUAL( fsize <= -52, false );
+}
+
+BOOST_AUTO_TEST_CASE( comparing_fsizes )
+{
+    FSize fsize(100);
+    FSize fsize_copy(fsize);
+    FSize fsize_double(100.0);
+    FSize fsize_negative(-100);
+    FSize fsize_different(200);
+
+    BOOST_CHECK_EQUAL( fsize, fsize_copy );
+    BOOST_CHECK_EQUAL( fsize, fsize_double );
+    BOOST_CHECK_NE( fsize, fsize_different );
+    BOOST_CHECK_NE( fsize, fsize_negative );
+
+    BOOST_CHECK_EQUAL( fsize <  fsize_copy, false );
+    BOOST_CHECK_EQUAL( fsize >  fsize_copy, false );
+    BOOST_CHECK_EQUAL( fsize <= fsize_copy, true );
+    BOOST_CHECK_EQUAL( fsize >= fsize_copy, true );
+    BOOST_CHECK_EQUAL( fsize <  fsize_different, true );
+    BOOST_CHECK_EQUAL( fsize >  fsize_different, false );
+    BOOST_CHECK_EQUAL( fsize <= fsize_different, true );
+    BOOST_CHECK_EQUAL( fsize >= fsize_different, false );
+}
+
+BOOST_AUTO_TEST_CASE( comparing_with_limits )
+{
+    // 2^1024
+    FSize fsize(cpp_int(1) << 1024);
+
+    // even bigger than the max long long
+    BOOST_CHECK(fsize > std::numeric_limits<long long>::max());
+    // even bigger than the max unsigned long long
+    BOOST_CHECK(fsize > std::numeric_limits<unsigned long long>::max());
+    // even bigger than the max double
+    BOOST_CHECK(fsize > std::numeric_limits<double>::max());
+
+    // compare with the negative limits
+    fsize *= -1;
+    // even lower than the min long long
+    BOOST_CHECK(fsize < std::numeric_limits<long long>::min());
+    // even lower than the min unsigned long long
+    BOOST_CHECK(fsize < std::numeric_limits<unsigned long long>::min());
+    // even lower than the min double
+    BOOST_CHECK(fsize < std::numeric_limits<double>::min());
+}
+
+BOOST_AUTO_TEST_CASE( operators_on_self )
+{
+    FSize fsize(42);
+
+    fsize += 42;
+    BOOST_CHECK(fsize == 84);
+    fsize -= 42;
+    BOOST_CHECK(fsize == 42);
+    fsize -= 42;
+    BOOST_CHECK(fsize == 0);
+    fsize -= 42;
+    BOOST_CHECK(fsize == -42);
+    fsize *= -1;
+    BOOST_CHECK(fsize == 42);
+    fsize *= 8;
+    BOOST_CHECK(fsize == 336);
+    fsize /= 6;
+    BOOST_CHECK(fsize == 56);
+
+    // check some bigger values, 10TiB
+    FSize fsize2(10, FSize::Unit::T);
+    // 10TiB / 10 => 1TiB
+    fsize2 /= 10;
+    BOOST_CHECK(fsize2 == FSize::TB);
+}
+
+BOOST_AUTO_TEST_CASE( operators )
+{
+    BOOST_CHECK_EQUAL(FSize(20) + FSize(22), 42);
+    BOOST_CHECK_EQUAL(FSize(64) - FSize(22), 42);
+    BOOST_CHECK_EQUAL(FSize(64) * FSize(4), 256);
+    BOOST_CHECK_EQUAL(FSize(1024) / FSize(8), 128);
+
+    BOOST_CHECK_EQUAL(20 + FSize(22), 42);
+    BOOST_CHECK_EQUAL(64 - FSize(22), 42);
+    BOOST_CHECK_EQUAL(64 * FSize(4), 256);
+    BOOST_CHECK_EQUAL(1024 / FSize(8), 128);
+
+    BOOST_CHECK_EQUAL(FSize(20) + 22, 42);
+    BOOST_CHECK_EQUAL(FSize(64) - 22, 42);
+    BOOST_CHECK_EQUAL(FSize(64) * 4, 256);
+    BOOST_CHECK_EQUAL(FSize(1024) / 8, 128);
+
+    // unary minus
+    BOOST_CHECK_EQUAL(-FSize(120), -120);
+
+    // increment/decrement
+    FSize test(120);
+    // post increment
+    BOOST_CHECK_EQUAL(test++, 120);
+    // changed
+    BOOST_CHECK_EQUAL(test, 121);
+    // pre increment
+    BOOST_CHECK_EQUAL(++test, 122);
+    // not changed
+    BOOST_CHECK_EQUAL(test, 122);
+
+    // post decrement
+    BOOST_CHECK_EQUAL(test--, 122);
+    // changed
+    BOOST_CHECK_EQUAL(test, 121);
+    // pre decrement
+    BOOST_CHECK_EQUAL(--test, 120);
+    // not changed
+    BOOST_CHECK_EQUAL(test, 120);
+}
+
+BOOST_AUTO_TEST_CASE( fillBlock )
+{
+    BOOST_CHECK_EQUAL(FSize(0).fillBlock(), 0);
+    BOOST_CHECK_EQUAL(FSize(1).fillBlock(), 1024);
+    BOOST_CHECK_EQUAL(FSize(4000).fillBlock(), 4096);
+    BOOST_CHECK_EQUAL(FSize(42 * 1024).fillBlock(), 42 * 1024);
+    BOOST_CHECK_EQUAL(FSize(42 * 1024).fillBlock(32 * 1024), 65536);
+
+    // fillBlock() changes the object
+    int value = 42 * 1024; // 42KiB
+    FSize fsize(value);
+    BOOST_CHECK_EQUAL(fsize.fillBlock(32 * 1024), 65536);
+    // not equal to the original size
+    BOOST_CHECK_NE(fsize, value);
+}
+
+BOOST_AUTO_TEST_CASE( fullBlock )
+{
+    BOOST_CHECK_EQUAL(FSize(0).fullBlock(), 0);
+    BOOST_CHECK_EQUAL(FSize(1).fullBlock(), 1024);
+    BOOST_CHECK_EQUAL(FSize(4000).fullBlock(), 4096);
+    BOOST_CHECK_EQUAL(FSize(42 * 1024).fullBlock(), 42 * 1024);
+    BOOST_CHECK_EQUAL(FSize(42 * 1024).fullBlock(32 * 1024), 65536);
+
+    // fullBlock() creates a new object
+    int value = 42 * 1024; // 42KiB
+    FSize fsize(value);
+    BOOST_CHECK_EQUAL(fsize.fullBlock(32 * 1024), 65536);
+    // not changed
+    BOOST_CHECK_EQUAL(fsize, value);
+}
+
+BOOST_AUTO_TEST_CASE( bestUnit )
+{
+    BOOST_CHECK_EQUAL(FSize(0).bestUnit(), FSize::Unit::B);
+    BOOST_CHECK_EQUAL(FSize(999).bestUnit(), FSize::Unit::B);
+    BOOST_CHECK_EQUAL(FSize(1023).bestUnit(), FSize::Unit::B);
+    BOOST_CHECK_EQUAL(FSize(1024).bestUnit(), FSize::Unit::K);
+
+    BOOST_CHECK_EQUAL(FSize(1L << 20).bestUnit(), FSize::Unit::M);
+    BOOST_CHECK_EQUAL(FSize(1L << 30).bestUnit(), FSize::Unit::G);
+    BOOST_CHECK_EQUAL(FSize(1L << 40).bestUnit(), FSize::Unit::T);
+    BOOST_CHECK_EQUAL(FSize(1L << 50).bestUnit(), FSize::Unit::P);
+    BOOST_CHECK_EQUAL(FSize(1L << 60).bestUnit(), FSize::Unit::E);
+    BOOST_CHECK_EQUAL(FSize(cpp_int(1) << 70).bestUnit(), FSize::Unit::Z);
+    BOOST_CHECK_EQUAL(FSize(cpp_int(1) << 80).bestUnit(), FSize::Unit::Y);
+}
+
+BOOST_AUTO_TEST_CASE( unit )
+{
+    BOOST_CHECK_EQUAL(FSize::unit(FSize::Unit::B), "B");
+    BOOST_CHECK_EQUAL(FSize::unit(FSize::Unit::K), "KiB");
+    BOOST_CHECK_EQUAL(FSize::unit(FSize::Unit::M), "MiB");
+    BOOST_CHECK_EQUAL(FSize::unit(FSize::Unit::G), "GiB");
+    BOOST_CHECK_EQUAL(FSize::unit(FSize::Unit::T), "TiB");
+    BOOST_CHECK_EQUAL(FSize::unit(FSize::Unit::P), "PiB");
+    BOOST_CHECK_EQUAL(FSize::unit(FSize::Unit::E), "EiB");
+    BOOST_CHECK_EQUAL(FSize::unit(FSize::Unit::Z), "ZiB");
+    BOOST_CHECK_EQUAL(FSize::unit(FSize::Unit::Y), "YiB");
+}
+
+BOOST_AUTO_TEST_CASE( form )
+{
+    BOOST_CHECK_EQUAL(FSize(0).form(), "0 B");
+    BOOST_CHECK_EQUAL(FSize(1).form(), "1 B");
+    BOOST_CHECK_EQUAL(FSize(1024).form(), "1.0 KiB");
+    BOOST_CHECK_EQUAL(FSize(-1024).form(), "-1.0 KiB");
+    BOOST_CHECK_EQUAL(FSize(FSize::MB).form(), "1.0 MiB");
+    BOOST_CHECK_EQUAL(FSize(123456789).form(), "117.7 MiB");
+    // requested unit
+    BOOST_CHECK_EQUAL(FSize(123456789).form(FSize::Unit::K), "120563.3 KiB");
+    BOOST_CHECK_EQUAL(FSize(123456789).form(FSize::Unit::M), "117.7 MiB");
+    BOOST_CHECK_EQUAL(FSize(123456789).form(FSize::Unit::G), "0.11 GiB");
+    // too small for the required unit
+    BOOST_CHECK_EQUAL(FSize(123456789).form(FSize::Unit::T), "0.000 TiB");
+    BOOST_CHECK_EQUAL(FSize(123456789).form(FSize::Unit::P), "0.000 PiB");
+    BOOST_CHECK_EQUAL(FSize(123456789).form(FSize::Unit::E), "0.000 EiB");
+    BOOST_CHECK_EQUAL(FSize(123456789).form(FSize::Unit::Z), "0.000 ZiB");
+    BOOST_CHECK_EQUAL(FSize(123456789).form(FSize::Unit::Y), "0.000 YiB");
+    
+    // field width
+    BOOST_CHECK_EQUAL(FSize(123456789).form(10), "     117.7 MiB");
+    // the width parameter does NOT include the units!
+    BOOST_CHECK_EQUAL(FSize(123456789).form(10).length(), 14);
+    // does not cut numbers for longer strings
+    BOOST_CHECK_EQUAL(FSize(123456789).form(FSize::Unit::K, 5), "120563.3 KiB");
+    
+    // precision
+    BOOST_CHECK_EQUAL(FSize(123456789).form(0, 3), "117.738 MiB");
+    BOOST_CHECK_EQUAL(FSize(123456789).form(0, 0), "118 MiB");
+    BOOST_CHECK_EQUAL(FSize(123456789).form(FSize::Unit::K, 0, 3), "120563.271 KiB");
+    BOOST_CHECK_EQUAL(FSize(123456789).form(FSize::Unit::K, 0, 0), "120563 KiB");
+    // precision for bytes is ignored
+    BOOST_CHECK_EQUAL(FSize(1234).form(FSize::Unit::B, 0, 3), "1234 B");
+    
+    // without units
+    BOOST_CHECK_EQUAL(FSize(123456789).form(0, 3, false), "117.738");
+    BOOST_CHECK_EQUAL(FSize(123456789).form(0, 0, false), "118");
+    BOOST_CHECK_EQUAL(FSize(123456789).form(FSize::Unit::K, 0, 3, false), "120563.271");
+    BOOST_CHECK_EQUAL(FSize(123456789).form(FSize::Unit::K, 0, 0, false), "120563");
+}
+
+BOOST_AUTO_TEST_CASE( as_string )
+{
+    // the same behavior like form(), test just few examples
+    BOOST_CHECK_EQUAL(FSize(0).asString(), "0 B");
+    BOOST_CHECK_EQUAL(FSize(1).asString(), "1 B");
+    BOOST_CHECK_EQUAL(FSize(1024).asString(), "1.0 KiB");
+    BOOST_CHECK_EQUAL(FSize(-1024).asString(), "-1.0 KiB");
+    BOOST_CHECK_EQUAL(FSize(123456789).asString(), "117.7 MiB");
+}
+
+template<class T> std::string to_stream(const T& object)
+{
+    std::ostringstream str;
+    
+    str << object;
+    return str.str();
+}
+
+BOOST_AUTO_TEST_CASE( output_operator )
+{
+    BOOST_CHECK_EQUAL(to_stream(FSize(0)), "0 B");
+    BOOST_CHECK_EQUAL(to_stream(FSize(1)), "1 B");
+    BOOST_CHECK_EQUAL(to_stream(FSize(1024)), "1.0 KiB");
+    BOOST_CHECK_EQUAL(to_stream(FSize(1024)), "1.0 KiB");
+    BOOST_CHECK_EQUAL(to_stream(FSize(123456789)), "117.7 MiB");
+
+    BOOST_CHECK_EQUAL(to_stream(FSize::Unit::B), "B");
+    BOOST_CHECK_EQUAL(to_stream(FSize::Unit::K), "KiB");
+    BOOST_CHECK_EQUAL(to_stream(FSize::Unit::M), "MiB");
+    BOOST_CHECK_EQUAL(to_stream(FSize::Unit::G), "GiB");
+    BOOST_CHECK_EQUAL(to_stream(FSize::Unit::T), "TiB");
+    BOOST_CHECK_EQUAL(to_stream(FSize::Unit::P), "PiB");
+    BOOST_CHECK_EQUAL(to_stream(FSize::Unit::E), "EiB");
+    BOOST_CHECK_EQUAL(to_stream(FSize::Unit::Z), "ZiB");
+    BOOST_CHECK_EQUAL(to_stream(FSize::Unit::Y), "YiB");
+}
+
+BOOST_AUTO_TEST_CASE( long_long_conversion )
+{
+    if (BOOST_VERSION >= 106700)
+    {
+        // Boost 1.67 returns min/max values for the values out of range
+        // https://www.boost.org/users/history/version_1_67_0.html
+        BOOST_CHECK_EQUAL((long long)(FSize::ZB), std::numeric_limits<long long>::max());
+        BOOST_CHECK_EQUAL((long long)(-FSize::YB), std::numeric_limits<long long>::min());
+    }
+    else
+    {
+        // the cpp_int convertion is buggy in older boost
+        // the older Boost (at least the 1.66 version) returns just the lower bits
+        // in that case just print a warning and continue
+        BOOST_WARN_EQUAL((long long)(FSize::ZB), std::numeric_limits<long long>::max());
+        BOOST_WARN_EQUAL((long long)(-FSize::YB), std::numeric_limits<long long>::min());
+    }
+}

--- a/tests/test_test.cc
+++ b/tests/test_test.cc
@@ -1,9 +1,0 @@
-
-#define BOOST_TEST_MODULE trivial_test
-#include <boost/test/unit_test.hpp>
-
-BOOST_AUTO_TEST_CASE( just_a_trivial_test_case )
-{
-    BOOST_CHECK_EQUAL( true, true );
-}
-


### PR DESCRIPTION
- Related to https://bugzilla.suse.com/show_bug.cgi?id=991090
- Use the [Boost multiprecision](https://www.boost.org/doc/libs/release/libs/multiprecision/doc/html/index.html) library instead of `long long` which overflows for values > 8EiB.
- Support higher units than TiB (up to YiB)
- Dropped the demo test, added an unit test for the FSize class
- Bump the .so version to 9.0.0
- What about the package version, should we bump to 4.0.0 as well?
- The pull requests for the Qt and ncurses frontends will follow