### PR TITLE
Pass $TRAVIS_JOB_ID to coveralls.io

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ before_install:
 script:
   # the "libyui-travis" script is included in the base libyui/devel image
   # see https://github.com/libyui/docker-devel/blob/master/libyui-travis
-  - docker run -it -e COVERALLS_TOKEN="$COVERALLS_TOKEN" libyui-image libyui-travis
+  - docker run -it -e COVERALLS_TOKEN="$COVERALLS_TOKEN" -e TRAVIS_JOB_ID="$TRAVIS_JOB_ID" libyui-image libyui-travis


### PR DESCRIPTION
- So the code coverage is properly evaluated.
- Without `$TRAVIS_JOB_ID` set all coverage is reported for the `HEAD` branch which is wrong
- When the coverage is assigned to the correct branch, see "Branch"  column in the "Recent Builds" section in https://coveralls.io/github/libyui/libyui
- After merging the code coverage in the main README.md should be correct