### PR TITLE
Add changes required for the libyui-rest-api

### DIFF
--- a/VERSION.cmake
+++ b/VERSION.cmake
@@ -1,6 +1,6 @@
 SET( VERSION_MAJOR "3")
-SET( VERSION_MINOR "4" )
-SET( VERSION_PATCH "2" )
+SET( VERSION_MINOR "5" )
+SET( VERSION_PATCH "0" )
 SET( VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}${GIT_SHA1_VERSION}" )
 
 ##### This is need for the libyui core, ONLY.
@@ -8,7 +8,7 @@ SET( VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}${GIT_SHA1_VERSI
 # Currently you must also change so_version in libyui.spec
 # *and also in **all** other* libyui-*.spec files in the other repositories.
 # Yes, such a design is suboptimal.
-SET( SONAME_MAJOR "9" )
+SET( SONAME_MAJOR "10" )
 SET( SONAME_MINOR "0" )
 SET( SONAME_PATCH "0" )
 SET( SONAME "${SONAME_MAJOR}.${SONAME_MINOR}.${SONAME_PATCH}" )

--- a/package/libyui-doc.spec
+++ b/package/libyui-doc.spec
@@ -17,10 +17,10 @@
 
 
 %define parent libyui
-%define so_version 9
+%define so_version 10
 
 Name:           %{parent}-doc
-Version:        3.4.2
+Version:        3.5.0
 Release:        0
 Source:         %{parent}-%{version}.tar.bz2
 

--- a/package/libyui.changes
+++ b/package/libyui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Dec 20 09:53:15 UTC 2018 - Rodion Iafarov <riafarov@suse.com>
+
+- Add changes required for the libyui-rest-api
+- 3.5.0
+
+-------------------------------------------------------------------
 Tue Aug 21 10:38:54 CEST 2018 - schubi@suse.de
 
 - Changed dir of COPYING file.
@@ -67,7 +73,7 @@ Fri Oct 14 10:22:44 UTC 2016 - jreidinger@suse.com
 -------------------------------------------------------------------
 Fri Oct 14 11:16:30 CEST 2016 - anaselli@linux.it
 
-- Fix pre-selecting a tree item when adding it, in ncurses 
+- Fix pre-selecting a tree item when adding it, in ncurses
   (gh#libyui/libyui#86, boo#1005889). The very first item would
   be selected, ignoring YTreeItem::setSelected.
 - Added ui test before loading extended widget plugin, to avoid

--- a/package/libyui.spec
+++ b/package/libyui.spec
@@ -16,11 +16,11 @@
 #
 
 Name:           libyui
-Version:        3.4.2
+Version:        3.5.0
 Release:        0
 Source:         %{name}-%{version}.tar.bz2
 
-%define so_version 9
+%define so_version 10
 %define bin_name %{name}%{so_version}
 
 # optionally build with code coverage reporting,

--- a/src/YPushButton.h
+++ b/src/YPushButton.h
@@ -216,6 +216,13 @@ public:
 	{ setLabel( str ); }
 
 
+    /**
+     * Activate the button. Can be used in tests to simulate user input.
+     *
+     * Derived classes are required to implement this.
+     **/
+    virtual void activate() = 0;
+
 private:
 
     ImplPtr<YPushButtonPrivate> priv;

--- a/src/YTable.cc
+++ b/src/YTable.cc
@@ -146,6 +146,32 @@ YTable::hasMultiSelection() const
     return ! YSelectionWidget::enforceSingleSelection();
 }
 
+YItem *
+YTable::findItem( const std::string & wantedItemLabel, int column ) const
+{
+    return YTable::findItem( wantedItemLabel, column, itemsBegin(), itemsEnd() );
+}
+
+
+YItem *
+YTable::findItem( const std::string & wantedItemLabel,
+                  int                 column,
+                  YItemConstIterator  begin,
+                  YItemConstIterator  end ) const
+{
+    if ( ! hasColumn( column ) )
+        return nullptr;
+
+    for ( YItemConstIterator it = begin; it != end; ++it )
+    {
+        auto * item = dynamic_cast<YTableItem *>(*it);
+
+        if ( item && item->label( column ) == wantedItemLabel )
+            return item;
+    }
+
+    return nullptr;
+}
 
 const YPropertySet &
 YTable::propertySet()

--- a/src/YTable.h
+++ b/src/YTable.h
@@ -144,6 +144,19 @@ public:
     bool hasMultiSelection() const;
 
     /**
+     * Try to find an item with label 'wantedItemLabel' in column 'column'
+     *  between iterators 'begin' and 'end'. Return that item or 0 if there is
+     *  none.
+     **/
+
+    YItem * findItem( const std::string & wantedItemLabel, int column ) const;
+
+    YItem * findItem( const std::string & wantedItemLabel,
+                      int                 column,
+                      YItemConstIterator  begin,
+                      YItemConstIterator  end ) const;
+
+    /**
      * Notification that a cell (its text and/or its icon) was changed from the
      * outside. Applications are required to call this whenever a table cell is
      * changed after adding the corresponding table item (the row) to the table

--- a/src/YUI.cc
+++ b/src/YUI.cc
@@ -48,6 +48,7 @@
 #include "YEnvVar.h"
 #include "YBuiltinCaller.h"
 #include "YWidgetID.h"
+#include "YUIPlugin.h"
 
 using std::endl;
 
@@ -76,6 +77,7 @@ YUI::YUI( bool withThreads )
 {
     yuiMilestone() << "This is libyui " << VERSION << std::endl;
     yuiMilestone() << "Creating UI " << ( withThreads ? "with" : "without" ) << " threads" << endl;
+
     _ui = this;
 }
 

--- a/src/YUILoader.h
+++ b/src/YUILoader.h
@@ -37,7 +37,7 @@
 #define YUIPlugin_Qt		"qt"
 #define YUIPlugin_NCurses	"ncurses"
 #define YUIPlugin_Gtk		"gtk"
-
+#define YUIPlugin_RestAPI       "rest-api"
 
 /**
  * Class to load one of the concrete UI plug-ins: Qt, NCurses, Gtk.
@@ -96,6 +96,12 @@ public:
      * the terminal settings are properly restored.
      **/
     static void deleteUI();
+
+    /**
+     * Method handles loading integration test framework and load underlying GUI
+     * using hints from loadUI.
+     **/
+    static void loadRestAPIPlugin( const std::string & wantedGUI, bool withThreads = false );
 
     /**
      * Load a UI plug-in. 'name' is one of the YUIPlugin_ -defines above.
@@ -160,5 +166,14 @@ typedef YUI * (*createUIFunction_t)( bool );
  * singleton for all subsequent calls.
  **/
 typedef YExternalWidgets * (*createEWFunction_t)( const char * );
+
+/**
+ * For the integration testing YUI has separate framework which allows to have
+ * control over UI using REST API. Server has to be started after testing framework
+ * plugin is loaded, which is done by the method which creates server instance.
+ * Not to have additional definition imports, we define it as void here.
+ * In the framework calls it can be used to
+**/
+typedef void (*getServerFunction_t)();
 
 #endif // YUILoader_h

--- a/src/YWizard.h
+++ b/src/YWizard.h
@@ -183,10 +183,19 @@ public:
     virtual void setDialogTitle( const std::string & titleText ) = 0;
 
     /**
+     * Get the current dialog title shown in the window manager's title bar.
+     **/
+    virtual std::string getDialogTitle() = 0;
+
+    /**
      * Set the dialog heading.
      **/
     virtual void setDialogHeading( const std::string & headingText ) = 0;
 
+    /**
+     * Get the dialog heading.
+     **/
+    virtual std::string getDialogHeading() = 0;
 
     //
     // Steps handling


### PR DESCRIPTION
Project started by @lslezak, with support of @cwh42 and @oleksandrorlov. After discussions we decided to split test framework to separate package not to introduce any security
flows.

So http server part went to https://github.com/rwx788/libyui-testframework
It compiles with `make` commands, but doesn't work with OBS yet as package is not created.
To test it I've adjusted libyui-qt and yast-yast2 packages. Ncurses is the next:
* https://github.com/yast/yast-yast2/pull/911
* https://github.com/libyui/libyui-qt/pull/103
* https://github.com/libyui/libyui-ncurses/pull/75
After these 4 packages are installed, one can execute following command:
`xdg-su -c 'Y2TEST=1 YUI_HTTP_PORT=9999 yast2 host'` for QT
and
`sudo Y2TEST=1 YUI_HTTP_PORT=9999 yast2 host` for ncurses.


Please, keep in mind that I don't have much experience with dynamic loading of the libraries, and I've ignored dlclose call for now as I assume that once testing lib is loaded it will be used till the app is closed.

What I don't like is having new method for plugin loading, I thought about having more generic one which can be used to load any library.

Solution is based on proposal provided by Ladi (https://hackweek.suse.com/17/projects/yast-integration-tests-using-cucumber) and just refactors things required to split packages.

To make it simpler, I've decided to have rest api in the single package, not to have 3 of them. This solution has disadvantage of the need to load qt and ncurses libraries even one of them won't be used and on top scenario will fail in case we have only ncurses version available. Alternative would be to split it to 3 packages, which I would like to avoid as of now.

See [poo#43742](https://progress.opensuse.org/issues/43742).