### PR TITLE
Scan command line for --threads/--nothreads

### DIFF
--- a/src/YUILoader.cc
+++ b/src/YUILoader.cc
@@ -119,6 +119,15 @@ void YUILoader::loadUI( bool withThreads )
 	wantedGUI = YUIPlugin_NCurses;
     }
 
+    if (cmdline.find("--threads") != -1) {
+        yuiMilestone () << "Explicitly enabling UI threads" << std::endl;
+        withThreads = true;
+    }
+    if (cmdline.find("--nothreads") != -1) {
+        yuiMilestone () << "Explicitly disabling UI threads" << std::endl;
+        withThreads = false;
+    }
+
     // Load the wanted UI-plugin.
     if( wantedGUI != "" )
     {


### PR DESCRIPTION
Related to https://bugzilla.suse.com/show_bug.cgi?id=1139967
This is a way to enable yui threads in the examples. Which makes them fail with
```
...
<_M_> [qt-ui] YQUI.cc:105 YQUI(): This is libyui-qt 2.50.4
<ERR> [qt-ui] YQUI.cc:687 qMessageHandler(): <libqt-fatal> QWidget: Must construct a QApplication before a QWidget
Aborted (core dumped)
```