### PR TITLE
added sort key to table cell

### DIFF
--- a/VERSION.cmake
+++ b/VERSION.cmake
@@ -1,6 +1,6 @@
 SET( VERSION_MAJOR "3")
 SET( VERSION_MINOR "9" )
-SET( VERSION_PATCH "0" )
+SET( VERSION_PATCH "1" )
 SET( VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}${GIT_SHA1_VERSION}" )
 
 ##### This is need for the libyui core, ONLY.
@@ -9,6 +9,6 @@ SET( VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}${GIT_SHA1_VERSI
 # *and also in **all** other* libyui-*.spec files in the other repositories.
 # Yes, such a design is suboptimal.
 SET( SONAME_MAJOR "11" )
-SET( SONAME_MINOR "0" )
+SET( SONAME_MINOR "1" )
 SET( SONAME_PATCH "0" )
 SET( SONAME "${SONAME_MAJOR}.${SONAME_MINOR}.${SONAME_PATCH}" )

--- a/package/libyui-doc.spec
+++ b/package/libyui-doc.spec
@@ -20,7 +20,7 @@
 %define so_version 11
 
 Name:           %{parent}-doc
-Version:        3.9.0
+Version:        3.9.1
 Release:        0
 Source:         %{parent}-%{version}.tar.bz2
 

--- a/package/libyui.changes
+++ b/package/libyui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Dec 18 11:12:13 CET 2019 - aschnell@suse.com
+
+- added sort key to table cell (bsc#1140018)
+- 3.9.1
+
+-------------------------------------------------------------------
 Fri Nov 29 14:38:54 UTC 2019 - Rodion Iafarov <riafarov@suse.com>
 
 - Add support to operate on many widgets with rest-api (bsc#1132247)

--- a/package/libyui.spec
+++ b/package/libyui.spec
@@ -16,7 +16,7 @@
 #
 
 Name:           libyui
-Version:        3.9.0
+Version:        3.9.1
 Release:        0
 Source:         %{name}-%{version}.tar.bz2
 

--- a/src/YTableItem.cc
+++ b/src/YTableItem.cc
@@ -114,9 +114,9 @@ YTableItem::addCell( YTableCell * cell )
 
 
 void
-YTableItem::addCell( const string & label, const string & iconName )
+YTableItem::addCell( const string & label, const string & iconName, const string & sortKey )
 {
-    YTableCell * cell = new YTableCell( label, iconName );
+    YTableCell * cell = new YTableCell( label, iconName, sortKey );
     YUI_CHECK_NEW( cell );
 
     addCell( cell );

--- a/src/YTableItem.h
+++ b/src/YTableItem.h
@@ -110,10 +110,11 @@ public:
     void addCell( YTableCell * cell_disown );
 
     /**
-     * Create a new cell and add it (even if both 'label' and
-     * 'iconName' are empty).
+     * Create a new cell and add it (even if all 'label',
+     * 'iconName' and 'sortKey' are empty).
      **/
-    void addCell( const std::string & label, const std::string & iconName = std::string() );
+    void addCell( const std::string & label, const std::string & iconName = std::string(),
+		  const std::string & sortKey = std::string() );
 
     /**
      * Delete all cells.
@@ -219,13 +220,15 @@ class YTableCell
 {
 public:
     /**
-     * Constructor with label and optional icon name for cells that don't have
-     * a parent item yet (that will be added to a parent later with
-     * setParent()).
+     * Constructor with label and optional icon name and optional sort
+     * key for cells that don't have a parent item yet (that will be
+     * added to a parent later with setParent()).
      **/
-    YTableCell( const std::string & label, const std::string & iconName = "" )
+    YTableCell( const std::string & label, const std::string & iconName = "",
+		const std::string & sortKey = "" )
         : _label( label )
         , _iconName( iconName )
+	, _sortKey( sortKey )
 	, _parent( 0 )
 	, _column ( -1 )
         {}
@@ -237,9 +240,11 @@ public:
     YTableCell( YTableItem *		parent,
 		int			column,
 		const std::string &	label,
-		const std::string &	iconName = "" )
+		const std::string &	iconName = "",
+		const std::string &     sortKey = "" )
         : _label( label )
         , _iconName( iconName )
+	, _sortKey( sortKey )
 	, _parent( parent )
 	, _column ( column )
         {}
@@ -287,6 +292,25 @@ public:
     void setIconName( const std::string & newIconName ) { _iconName = newIconName; }
 
     /**
+     * Return this cell's sort key.
+     **/
+    std::string sortKey() const { return _sortKey; }
+
+    /**
+     * Return 'true' if this cell has a sort key.
+     **/
+    bool hasSortKey() const { return ! _sortKey.empty(); }
+
+    /**
+     * Set this cell's sort key.
+     *
+     * If this is called after the corresponding table item (table row) is
+     * added to the table widget, call YTable::cellChanged() to notify the
+     * table widget about the fact. Only then will the display be updated.
+     **/
+    void setSortKey( const std::string & newSortKey ) { _sortKey = newSortKey; }
+
+    /**
      * Return this cell's parent item or 0 if it doesn't have one yet.
      **/
     YTableItem * parent() const { return _parent; }
@@ -316,6 +340,7 @@ private:
 
     std::string		_label;
     std::string		_iconName;
+    std::string         _sortKey;
     YTableItem *	_parent;
     int			_column;
 };

--- a/src/YUISymbols.h
+++ b/src/YUISymbols.h
@@ -334,6 +334,7 @@
 #define YUISymbol_id				"id"
 #define YUISymbol_opt				"opt"
 #define YUISymbol_icon				"icon"
+#define YUISymbol_sortKey			"sortKey"
 #define YUISymbol_item				"item"
 #define YUISymbol_cell				"cell"
 #define YUISymbol_menu				"menu"


### PR DESCRIPTION
This PR adds a sort key to the table cell (YTableCell). With support in libyui-{qt,ncurses} this will enable proper sorting of e.g. device names ("sda2" < "sda10") and device sizes ("2 KiB" < "1 MiB").