### PR TITLE
add unsigned long long cast operator

### DIFF
--- a/src/FSize.h
+++ b/src/FSize.h
@@ -146,6 +146,7 @@ class FSize :
      *   - 1.66 - returns just the lower bits
      **/
     explicit operator long long() const { return static_cast<long long>(_size); }
+    explicit operator unsigned long long() const { return static_cast<unsigned long long>(_size); }
     explicit operator int() const { return static_cast<int>(_size); }
     explicit operator double() const { return static_cast<double>(_size); }
 

--- a/tests/FSize_test.cc
+++ b/tests/FSize_test.cc
@@ -177,9 +177,9 @@ BOOST_AUTO_TEST_CASE( comparing_with_limits )
     FSize fsize(cpp_int(1) << 1024);
 
     // even bigger than the max long long
-    BOOST_CHECK(fsize > std::numeric_limits<long long>::max());
+    BOOST_CHECK((long long)fsize > std::numeric_limits<long long>::max());
     // even bigger than the max unsigned long long
-    BOOST_CHECK(fsize > std::numeric_limits<unsigned long long>::max());
+    BOOST_CHECK((unsigned long long)fsize > std::numeric_limits<unsigned long long>::max());
     // even bigger than the max double
     BOOST_CHECK(fsize > std::numeric_limits<double>::max());
 


### PR DESCRIPTION
helps fix
FSize_test.cc:180:25: error: implicit conversion from 'long long' to 'double' changes value from 9223372036854775807 to 9223372036854775808 [-Werror,-Wimplicit-int-float-conversion]

Signed-off-by: Khem Raj <raj.khem@gmail.com>