### PR TITLE
Fixing crash on YTable deletion in libyui-bindings

### DIFF
--- a/src/YWidgetFactory.h
+++ b/src/YWidgetFactory.h
@@ -109,7 +109,7 @@ public:
     virtual YComboBox *		createComboBox		( YWidget * parent, const std::string & label, bool editable	 = false )	= 0;
     virtual YSelectionBox *	createSelectionBox	( YWidget * parent, const std::string & label )					= 0;
     virtual YTree *		createTree		( YWidget * parent, const std::string & label, bool multiselection = false, bool recursiveselection = false ) = 0;
-    virtual YTable *		createTable		( YWidget * parent, YTableHeader * header,     bool multiSelection = false )	= 0;
+    virtual YTable *		createTable		( YWidget * parent, YTableHeader * header_disown,     bool multiSelection = false )	= 0;
     virtual YProgressBar *	createProgressBar	( YWidget * parent, const std::string & label, int  maxValue	   = 100   )	= 0;
     virtual YRichText *		createRichText		( YWidget * parent, const std::string & text = std::string(), bool plainTextMode = false )	= 0;
     virtual YBusyIndicator *	createBusyIndicator	( YWidget * parent, const std::string & label, int timeout = 1000 )		= 0;


### PR DESCRIPTION
With recent changes I experienced a crash using YTable in libyui-bindings (either perl or python).
According to [yui.i](https://github.com/libyui/libyui-bindings/blob/master/swig/yui.i#L166) in libyui-bindings and swig requirements it seemed a disown problem to me and added back disown for table header. 
Suggested patch fixed the problem after rebuilding libyui-bindings. 