### PR TITLE
New Widget: MenuBar

### DIFF
--- a/SOURCECONF.cmake
+++ b/SOURCECONF.cmake
@@ -15,6 +15,7 @@ SET( ${TARGETLIB}_SOURCES
   YItem.cc
   YIconLoader.cc
   YMacro.cc
+  YMenuItem.cc
   YProperty.cc
   YShortcut.cc
   YShortcutManager.cc
@@ -109,10 +110,10 @@ SET( ${TARGETLIB}_HEADERS
   YItem.h
   YItemCustomStatus.h
   YIconLoader.h
-  YMenuItem.h
   YMacro.h
   YMacroPlayer.h
   YMacroRecorder.h
+  YMenuItem.h
   YPackageSelectorPlugin.h
   YGraphPlugin.h
   YProperty.h
@@ -203,6 +204,7 @@ SET( EXAMPLES_LIST
   ItemSelector2-minimalistic.cc
   ManyWidgets.cc
   MenuBar1.cc
+  MenuBar2.cc
   MenuButton1.cc
   PollEvent.cc
   SelectionBox1.cc

--- a/SOURCECONF.cmake
+++ b/SOURCECONF.cmake
@@ -56,6 +56,7 @@ SET( ${TARGETLIB}_SOURCES
   YLogView.cc
   YMenuBar.cc
   YMenuButton.cc
+  YMenuWidget.cc
   YMultiLineEdit.cc
   YMultiProgressMeter.cc
   YMultiSelectionBox.cc
@@ -157,6 +158,7 @@ SET( ${TARGETLIB}_HEADERS
   YLogView.h
   YMenuBar.h
   YMenuButton.h
+  YMenuWidget.h
   YMultiLineEdit.h
   YMultiProgressMeter.h
   YMultiSelectionBox.h

--- a/SOURCECONF.cmake
+++ b/SOURCECONF.cmake
@@ -202,7 +202,8 @@ SET( EXAMPLES_LIST
   ItemSelector1.cc
   ItemSelector2-minimalistic.cc
   ManyWidgets.cc
-  MenuButtons.cc
+  MenuBar1.cc
+  MenuButton1.cc
   PollEvent.cc
   SelectionBox1.cc
   SelectionBox2.cc

--- a/SOURCECONF.cmake
+++ b/SOURCECONF.cmake
@@ -54,6 +54,7 @@ SET( ${TARGETLIB}_SOURCES
   YLabel.cc
   YLayoutBox.cc
   YLogView.cc
+  YMenuBar.cc
   YMenuButton.cc
   YMultiLineEdit.cc
   YMultiProgressMeter.cc
@@ -154,6 +155,7 @@ SET( ${TARGETLIB}_HEADERS
   YLabel.h
   YLayoutBox.h
   YLogView.h
+  YMenuBar.h
   YMenuButton.h
   YMultiLineEdit.h
   YMultiProgressMeter.h

--- a/VERSION.cmake
+++ b/VERSION.cmake
@@ -1,6 +1,6 @@
 SET( VERSION_MAJOR "3")
-SET( VERSION_MINOR "10" )
-SET( VERSION_PATCH "1" )
+SET( VERSION_MINOR "11" )
+SET( VERSION_PATCH "0" )
 SET( VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}${GIT_SHA1_VERSION}" )
 
 ##### This is need for the libyui core, ONLY.
@@ -8,7 +8,7 @@ SET( VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}${GIT_SHA1_VERSI
 # Currently you must also change so_version in libyui.spec
 # *and also in **all** other* libyui-*.spec files in the other repositories.
 # Yes, such a design is suboptimal.
-SET( SONAME_MAJOR "12" )
+SET( SONAME_MAJOR "13" )
 SET( SONAME_MINOR "0" )
 SET( SONAME_PATCH "0" )
 SET( SONAME "${SONAME_MAJOR}.${SONAME_MINOR}.${SONAME_PATCH}" )

--- a/examples/MenuBar1.cc
+++ b/examples/MenuBar1.cc
@@ -27,6 +27,7 @@
 #include "YAlignment.h"
 #include "YDialog.h"
 #include "YLabel.h"
+#include "YCheckBox.h"
 #include "YLayoutBox.h"
 #include "YMenuBar.h"
 #include "YSquash.h"
@@ -40,50 +41,52 @@ using std::string;
 
 // Widgets
 
-YDialog * dialog                = 0;
-YLabel  * lastEventLabel        = 0;
+YDialog	  * dialog		= 0;
+YMenuBar  * menuBar		= 0;
+YLabel	  * lastEventLabel	= 0;
+YCheckBox * readOnlyCheckBox	= 0;
 
 
 // Menus and Menu Items
 
-YMenuItem * fileMenu            = 0;
-YMenuItem * editMenu            = 0;
-YMenuItem * viewMenu            = 0;
-YMenuItem * optionsMenu         = 0;
+YMenuItem * fileMenu		= 0;
+YMenuItem * editMenu		= 0;
+YMenuItem * viewMenu		= 0;
+YMenuItem * optionsMenu		= 0;
 
 
 // "File" menu
 
-YMenuItem * actionOpen          = 0;
-YMenuItem * actionSave          = 0;
-YMenuItem * actionSaveAs        = 0;
-YMenuItem * actionQuit          = 0;
+YMenuItem * actionOpen		= 0;
+YMenuItem * actionSave		= 0;
+YMenuItem * actionSaveAs	= 0;
+YMenuItem * actionQuit		= 0;
 
 
 // "Edit" menu
 
-YMenuItem * actionCut           = 0;
-YMenuItem * actionCopy          = 0;
-YMenuItem * actionPaste         = 0;
+YMenuItem * actionCut		= 0;
+YMenuItem * actionCopy		= 0;
+YMenuItem * actionPaste		= 0;
 
 
 // "View" menu
 
-YMenuItem * actionViewNormal    = 0;
-YMenuItem * actionViewCompact   = 0;
-YMenuItem * actionViewDetailed  = 0;
+YMenuItem * actionViewNormal	= 0;
+YMenuItem * actionViewCompact	= 0;
+YMenuItem * actionViewDetailed	= 0;
 
 
 // "View" -> "Zoom" submenu
 
-YMenuItem * zoomMenu            = 0;
-YMenuItem * actionZoomIn        = 0;
-YMenuItem * actionZoomOut       = 0;
-YMenuItem * actionZoomDefault   = 0;
+YMenuItem * zoomMenu		= 0;
+YMenuItem * actionZoomIn	= 0;
+YMenuItem * actionZoomOut	= 0;
+YMenuItem * actionZoomDefault	= 0;
 
 // "Options" menu
 
-YMenuItem * actionSettings      = 0;
+YMenuItem * actionSettings	= 0;
 
 
 // Function Prototypes
@@ -92,6 +95,7 @@ void createWidgets();
 void addMenus( YMenuBar * menuBar );
 void handleEvents();
 void showEvent( YMenuEvent * event );
+void updateActions();
 
 
 
@@ -102,6 +106,7 @@ int main( int argc, char **argv )
     YUILog::enableDebugLogging();
 
     createWidgets();
+    updateActions();
     handleEvents();
 
     dialog->destroy();
@@ -119,20 +124,24 @@ void createWidgets()
 
     dialog		 = fac->createPopupDialog();
     YAlignment * minSize = fac->createMinSize( dialog, 50, 20 );
-    YLayoutBox * vbox1   = fac->createVBox( minSize );
-    YMenuBar   * menuBar = fac->createMenuBar( vbox1 );
+    YLayoutBox * vbox1	 = fac->createVBox( minSize );
+    menuBar		 = fac->createMenuBar( vbox1 );
 
     addMenus( menuBar );
 
-    YAlignment * center  = fac->createHVCenter( vbox1 );
-    YSquash    * squash  = fac->createHVSquash( center );
-    YLayoutBox * vbox2   = fac->createVBox( squash );
+    YAlignment * center	 = fac->createHVCenter( vbox1 );
+    YSquash    * squash	 = fac->createHVSquash( center );
+    YLayoutBox * vbox2	 = fac->createVBox( squash );
 
     YAlignment * left = fac->createLeft( vbox2 );
     fac->createLabel   ( left, "Last Event:" );
     fac->createVSpacing( vbox2, 0.2 );
     YAlignment * minWidth = fac->createMinWidth( vbox2, 15 );
     lastEventLabel = fac->createOutputField( minWidth, "<none>" );
+
+    fac->createVSpacing( vbox2, 2 );
+    readOnlyCheckBox = fac->createCheckBox( vbox2, "Read &Only", true );
+    readOnlyCheckBox->setNotify( true );
 }
 
 
@@ -141,32 +150,32 @@ void addMenus( YMenuBar * menuBar )
     // The difference between a menu and a plain menu item is just that the
     // menu has child items whild the plain item does not.
 
-    fileMenu    = menuBar->addMenu( "&File" );
-    editMenu    = menuBar->addMenu( "&Edit" );
-    viewMenu    = menuBar->addMenu( "&View" );
+    fileMenu	= menuBar->addMenu( "&File" );
+    editMenu	= menuBar->addMenu( "&Edit" );
+    viewMenu	= menuBar->addMenu( "&View" );
     optionsMenu = menuBar->addMenu( "&Options" );
 
-    actionOpen          = fileMenu->addItem( "&Open..."    );
-    actionSave          = fileMenu->addItem( "&Save"       );
-    actionSaveAs        = fileMenu->addItem( "Save &As..." );
+    actionOpen		= fileMenu->addItem( "&Open..."	   );
+    actionSave		= fileMenu->addItem( "&Save"	   );
+    actionSaveAs	= fileMenu->addItem( "Save &As..." );
     fileMenu->addSeparator();
-    actionQuit          = fileMenu->addItem( "&Quit" );
+    actionQuit		= fileMenu->addItem( "&Quit" );
 
-    actionCut           = editMenu->addItem( "C&ut"   );
-    actionCopy          = editMenu->addItem( "&Copy"  );
-    actionPaste         = editMenu->addItem( "&Paste" );
+    actionCut		= editMenu->addItem( "C&ut"   );
+    actionCopy		= editMenu->addItem( "&Copy"  );
+    actionPaste		= editMenu->addItem( "&Paste" );
 
-    actionViewNormal    = viewMenu->addItem( "&Normal"   );
-    actionViewCompact   = viewMenu->addItem( "&Compact"  );
-    actionViewDetailed  = viewMenu->addItem( "&Detailed" );
+    actionViewNormal	= viewMenu->addItem( "&Normal"	 );
+    actionViewCompact	= viewMenu->addItem( "&Compact"	 );
+    actionViewDetailed	= viewMenu->addItem( "&Detailed" );
     viewMenu->addSeparator();
-    zoomMenu            = viewMenu->addMenu( "&Zoom" );
+    zoomMenu		= viewMenu->addMenu( "&Zoom" );
 
-    actionZoomIn        = zoomMenu->addItem( "Zoom &In"      );
-    actionZoomOut       = zoomMenu->addItem( "Zoom &Out"     );
-    actionZoomDefault   = zoomMenu->addItem( "Zoom &Default" );
+    actionZoomIn	= zoomMenu->addItem( "Zoom &In"	     );
+    actionZoomOut	= zoomMenu->addItem( "Zoom &Out"     );
+    actionZoomDefault	= zoomMenu->addItem( "Zoom &Default" );
 
-    actionSettings      = optionsMenu->addItem( "&Settings..." );
+    actionSettings	= optionsMenu->addItem( "&Settings..." );
 
     menuBar->resolveShortcutConflicts();
     menuBar->rebuildMenuTree();
@@ -191,18 +200,21 @@ void handleEvents()
 		break; // leave event loop
 	    }
 
-            if ( event->eventType() == YEvent::MenuEvent )
-            {
-                YMenuEvent * menuEvent = dynamic_cast<YMenuEvent *>( event );
+	    if ( event->eventType() == YEvent::MenuEvent )
+	    {
+		YMenuEvent * menuEvent = dynamic_cast<YMenuEvent *>( event );
 
-                if ( menuEvent )
-                {
-                    showEvent( menuEvent );
+		if ( menuEvent )
+		{
+		    showEvent( menuEvent );
 
-                    if ( menuEvent->item() == actionQuit )
-                        break; // leave event loop
-                }
-            }
+		    if ( menuEvent->item() == actionQuit )
+			break; // leave event loop
+		}
+	    }
+
+	    if ( event->widget() == readOnlyCheckBox )
+		updateActions();
 	}
     }
 }
@@ -216,7 +228,21 @@ void showEvent( YMenuEvent * event )
 {
     if ( event && event->item() )
     {
-        string text = YShortcut::cleanShortcutString( event->item()->label() );
-        lastEventLabel->setLabel( text );
+	string text = YShortcut::cleanShortcutString( event->item()->label() );
+	lastEventLabel->setLabel( text );
     }
+}
+
+
+/**
+ * Update the available menu actions: Enable or disable some of them according
+ * to the current status of the "Read Only" check box.
+ **/
+void updateActions()
+{
+    bool readOnly = readOnlyCheckBox->isChecked();
+
+    menuBar->setItemEnabled( actionSave,  ! readOnly );
+    menuBar->setItemEnabled( actionCut,	  ! readOnly );
+    menuBar->setItemEnabled( actionPaste, ! readOnly );
 }

--- a/examples/MenuBar1.cc
+++ b/examples/MenuBar1.cc
@@ -1,0 +1,223 @@
+/*
+  Copyright (c) [2020] SUSE LLC
+  This library is free software; you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as
+  published by the Free Software Foundation; either version 2.1 of the
+  License, or (at your option) version 3.0 of the License. This library
+  is distributed in the hope that it will be useful, but WITHOUT ANY
+  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+  FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+  License for more details. You should have received a copy of the GNU
+  Lesser General Public License along with this library; if not, write
+  to the Free Software Foundation, Inc., 51 Franklin Street, Fifth
+  Floor, Boston, MA 02110-1301 USA
+*/
+
+
+// MenuBar example.
+//
+// Compile with:
+//
+//     g++ -I/usr/include/yui -lyui MenuBar1.cc -o MenuBar1
+
+#define YUILogComponent "example"
+#include "YUILog.h"
+
+#include "YUI.h"
+#include "YAlignment.h"
+#include "YDialog.h"
+#include "YLabel.h"
+#include "YLayoutBox.h"
+#include "YMenuBar.h"
+#include "YSquash.h"
+#include "YWidgetFactory.h"
+#include "YShortcut.h"
+#include "YEvent.h"
+
+
+using std::string;
+
+
+// Widgets
+
+YDialog * dialog                = 0;
+YLabel  * lastEventLabel        = 0;
+
+
+// Menus and Menu Items
+
+YMenuItem * fileMenu            = 0;
+YMenuItem * editMenu            = 0;
+YMenuItem * viewMenu            = 0;
+YMenuItem * optionsMenu         = 0;
+
+
+// "File" menu
+
+YMenuItem * actionOpen          = 0;
+YMenuItem * actionSave          = 0;
+YMenuItem * actionSaveAs        = 0;
+YMenuItem * actionQuit          = 0;
+
+
+// "Edit" menu
+
+YMenuItem * actionCut           = 0;
+YMenuItem * actionCopy          = 0;
+YMenuItem * actionPaste         = 0;
+
+
+// "View" menu
+
+YMenuItem * actionViewNormal    = 0;
+YMenuItem * actionViewCompact   = 0;
+YMenuItem * actionViewDetailed  = 0;
+
+
+// "View" -> "Zoom" submenu
+
+YMenuItem * zoomMenu            = 0;
+YMenuItem * actionZoomIn        = 0;
+YMenuItem * actionZoomOut       = 0;
+YMenuItem * actionZoomDefault   = 0;
+
+// "Options" menu
+
+YMenuItem * actionSettings      = 0;
+
+
+// Function Prototypes
+
+void createWidgets();
+void addMenus( YMenuBar * menuBar );
+void handleEvents();
+void showEvent( YMenuEvent * event );
+
+
+
+
+int main( int argc, char **argv )
+{
+    YUILog::setLogFileName( "/tmp/libyui-examples.log" );
+    YUILog::enableDebugLogging();
+
+    createWidgets();
+    handleEvents();
+
+    dialog->destroy();
+}
+
+
+/**
+ * Create the widget tree for the main dialog
+ **/
+void createWidgets()
+{
+    yuiMilestone() << endl;
+
+    YWidgetFactory * fac = YUI::widgetFactory();
+
+    dialog		 = fac->createPopupDialog();
+    YAlignment * minSize = fac->createMinSize( dialog, 50, 20 );
+    YLayoutBox * vbox1   = fac->createVBox( minSize );
+    YMenuBar   * menuBar = fac->createMenuBar( vbox1 );
+
+    addMenus( menuBar );
+
+    YAlignment * center  = fac->createHVCenter( vbox1 );
+    YSquash    * squash  = fac->createHVSquash( center );
+    YLayoutBox * vbox2   = fac->createVBox( squash );
+
+    YAlignment * left = fac->createLeft( vbox2 );
+    fac->createLabel   ( left, "Last Event:" );
+    fac->createHSpacing( vbox2, 1 );
+    lastEventLabel = fac->createOutputField( vbox2, "<none>" );
+    lastEventLabel->setStretchable( YD_HORIZ, true );
+    fac->createMinWidth( vbox2, 20 );
+}
+
+
+void addMenus( YMenuBar * menuBar )
+{
+    fileMenu    = new YMenuItem( "&File" );
+    editMenu    = new YMenuItem( "&Edit" );
+    viewMenu    = new YMenuItem( "&View" );
+    optionsMenu = new YMenuItem( "&Options" );
+
+    actionOpen          = new YMenuItem( fileMenu, "&Open..."    );
+    actionSave          = new YMenuItem( fileMenu, "&Save"       );
+    actionSaveAs        = new YMenuItem( fileMenu, "Save &As..." );
+    actionQuit          = new YMenuItem( fileMenu, "&Quit"       );
+
+    actionCut           = new YMenuItem( editMenu, "C&ut"   );
+    actionCopy          = new YMenuItem( editMenu, "&Copy"  );
+    actionPaste         = new YMenuItem( editMenu, "&Paste" );
+
+    actionViewNormal    = new YMenuItem( viewMenu, "&Normal"   );
+    actionViewCompact   = new YMenuItem( viewMenu, "&Compact"  );
+    actionViewDetailed  = new YMenuItem( viewMenu, "&Detailed" );
+
+    zoomMenu            = new YMenuItem( viewMenu, "&Zoom"         );
+    actionZoomIn        = new YMenuItem( zoomMenu, "Zoom &In"      );
+    actionZoomOut       = new YMenuItem( zoomMenu, "Zoom &Out"     );
+    actionZoomDefault   = new YMenuItem( zoomMenu, "Zoom &Default" );
+
+    actionSettings      = new YMenuItem( optionsMenu, "&Settings..." );
+
+    menuBar->addItem( fileMenu );
+    menuBar->addItem( editMenu );
+    menuBar->addItem( viewMenu );
+    menuBar->addItem( optionsMenu );
+
+    // Do NOT add all the individual items separately to the menu bar:
+    // They are owned by their parent menu.
+
+    menuBar->resolveShortcutConflicts();
+    menuBar->rebuildMenuTree();
+}
+
+
+/**
+ * Event loop and event handling for the main dialog
+ **/
+void handleEvents()
+{
+    yuiMilestone() << endl;
+
+    while ( true )
+    {
+	YEvent * event = dialog->waitForEvent();
+
+	if ( event )
+	{
+	    if ( event->eventType() == YEvent::CancelEvent ) // window manager "close window" button
+	    {
+		break; // leave event loop
+	    }
+
+            if ( event->eventType() == YEvent::MenuEvent )
+            {
+                YMenuEvent * menuEvent = dynamic_cast<YMenuEvent *>( event );
+
+                if ( menuEvent )
+                {
+                    showEvent( menuEvent );
+                    
+                    if ( menuEvent->item() == actionQuit )
+                        break; // leave event loop
+                }
+            }
+	}
+    }
+}
+
+
+void showEvent( YMenuEvent * event )
+{
+    if ( event && event->item() )
+    {
+        string text = YShortcut::cleanShortcutString( event->item()->label() );
+        
+        lastEventLabel->setLabel( text );
+    }
+}

--- a/examples/MenuBar1.cc
+++ b/examples/MenuBar1.cc
@@ -130,10 +130,9 @@ void createWidgets()
 
     YAlignment * left = fac->createLeft( vbox2 );
     fac->createLabel   ( left, "Last Event:" );
-    fac->createHSpacing( vbox2, 1 );
-    lastEventLabel = fac->createOutputField( vbox2, "<none>" );
-    lastEventLabel->setStretchable( YD_HORIZ, true );
-    fac->createMinWidth( vbox2, 20 );
+    fac->createVSpacing( vbox2, 0.2 );
+    YAlignment * minWidth = fac->createMinWidth( vbox2, 15 );
+    lastEventLabel = fac->createOutputField( minWidth, "<none>" );
 }
 
 

--- a/examples/MenuBar2.cc
+++ b/examples/MenuBar2.cc
@@ -18,7 +18,7 @@
 //
 // Compile with:
 //
-//     g++ -I/usr/include/yui -lyui MenuBar1.cc -o MenuBar1
+//     g++ -I/usr/include/yui -lyui MenuBar2.cc -o MenuBar2
 
 #define YUILogComponent "example"
 #include "YUILog.h"
@@ -139,35 +139,55 @@ void createWidgets()
 
 void addMenus( YMenuBar * menuBar )
 {
+    // This uses the more generic, but also more clumsy API:
+    //
+    // Each object in a menu is just a YMenuItem, no matter if it's a
+    // menu/submenu, a plain item or a separator.
+    //
     // The difference between a menu and a plain menu item is just that the
-    // menu has child items whild the plain item does not.
+    // menu has child items whild the plain item does not. A separator is just
+    // a menu item with an empty label.
+    //
+    // For the more elagant and more self-descriptive API, see the MenuBar1.cc
+    // example.
 
-    fileMenu    = menuBar->addMenu( "&File" );
-    editMenu    = menuBar->addMenu( "&Edit" );
-    viewMenu    = menuBar->addMenu( "&View" );
-    optionsMenu = menuBar->addMenu( "&Options" );
+    fileMenu    = new YMenuItem( "&File" );
+    editMenu    = new YMenuItem( "&Edit" );
+    viewMenu    = new YMenuItem( "&View" );
+    optionsMenu = new YMenuItem( "&Options" );
 
-    actionOpen          = fileMenu->addItem( "&Open..."    );
-    actionSave          = fileMenu->addItem( "&Save"       );
-    actionSaveAs        = fileMenu->addItem( "Save &As..." );
-    fileMenu->addSeparator();
-    actionQuit          = fileMenu->addItem( "&Quit" );
+    actionOpen          = new YMenuItem( fileMenu, "&Open..."    );
+    actionSave          = new YMenuItem( fileMenu, "&Save"       );
+    actionSaveAs        = new YMenuItem( fileMenu, "Save &As..." );
 
-    actionCut           = editMenu->addItem( "C&ut"   );
-    actionCopy          = editMenu->addItem( "&Copy"  );
-    actionPaste         = editMenu->addItem( "&Paste" );
+    new YMenuItem( fileMenu, "" ); // separator
 
-    actionViewNormal    = viewMenu->addItem( "&Normal"   );
-    actionViewCompact   = viewMenu->addItem( "&Compact"  );
-    actionViewDetailed  = viewMenu->addItem( "&Detailed" );
-    viewMenu->addSeparator();
-    zoomMenu            = viewMenu->addMenu( "&Zoom" );
+    actionQuit          = new YMenuItem( fileMenu, "&Quit"       );
 
-    actionZoomIn        = zoomMenu->addItem( "Zoom &In"      );
-    actionZoomOut       = zoomMenu->addItem( "Zoom &Out"     );
-    actionZoomDefault   = zoomMenu->addItem( "Zoom &Default" );
+    actionCut           = new YMenuItem( editMenu, "C&ut"   );
+    actionCopy          = new YMenuItem( editMenu, "&Copy"  );
+    actionPaste         = new YMenuItem( editMenu, "&Paste" );
 
-    actionSettings      = optionsMenu->addItem( "&Settings..." );
+    actionViewNormal    = new YMenuItem( viewMenu, "&Normal"   );
+    actionViewCompact   = new YMenuItem( viewMenu, "&Compact"  );
+    actionViewDetailed  = new YMenuItem( viewMenu, "&Detailed" );
+
+    new YMenuItem( viewMenu, "" ); // separator
+
+    zoomMenu            = new YMenuItem( viewMenu, "&Zoom"         );
+    actionZoomIn        = new YMenuItem( zoomMenu, "Zoom &In"      );
+    actionZoomOut       = new YMenuItem( zoomMenu, "Zoom &Out"     );
+    actionZoomDefault   = new YMenuItem( zoomMenu, "Zoom &Default" );
+
+    actionSettings      = new YMenuItem( optionsMenu, "&Settings..." );
+
+    menuBar->addItem( fileMenu );
+    menuBar->addItem( editMenu );
+    menuBar->addItem( viewMenu );
+    menuBar->addItem( optionsMenu );
+
+    // Do NOT add all the individual items separately to the menu bar:
+    // They are owned by their parent menu.
 
     menuBar->resolveShortcutConflicts();
     menuBar->rebuildMenuTree();

--- a/examples/MenuBar2.cc
+++ b/examples/MenuBar2.cc
@@ -130,10 +130,9 @@ void createWidgets()
 
     YAlignment * left = fac->createLeft( vbox2 );
     fac->createLabel   ( left, "Last Event:" );
-    fac->createHSpacing( vbox2, 1 );
-    lastEventLabel = fac->createOutputField( vbox2, "<none>" );
-    lastEventLabel->setStretchable( YD_HORIZ, true );
-    fac->createMinWidth( vbox2, 20 );
+    fac->createVSpacing( vbox2, 0.2 );
+    YAlignment * minWidth = fac->createMinWidth( vbox2, 15 );
+    lastEventLabel = fac->createOutputField( minWidth, "<none>" );
 }
 
 

--- a/examples/MenuButton1.cc
+++ b/examples/MenuButton1.cc
@@ -26,7 +26,7 @@
 //
 // Compile with:
 //
-//     g++ -I/usr/include/yui -lyui MenuButtons.cc -o MenuButtons
+//     g++ -I/usr/include/yui -lyui MenuButton1.cc -o MenuButton1
 
 #include "YUI.h"
 #include "YWidgetFactory.h"

--- a/examples/MenuButton1.cc
+++ b/examples/MenuButton1.cc
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2016 SUSE LCC
+  Copyright (c) [2016-2020] SUSE LCC
 
   Permission is hereby granted, free of charge, to any person obtaining
   a copy of this software and associated documentation files (the
@@ -28,6 +28,9 @@
 //
 //     g++ -I/usr/include/yui -lyui MenuButton1.cc -o MenuButton1
 
+#define YUILogComponent "example"
+#include "YUILog.h"
+
 #include "YUI.h"
 #include "YWidgetFactory.h"
 #include "YDialog.h"
@@ -38,22 +41,32 @@
 
 int main( int argc, char **argv )
 {
-    YDialog    * dialog = YUI::widgetFactory()->createPopupDialog();
-    YLayoutBox * vbox   = YUI::widgetFactory()->createVBox( dialog );
-    YUI::widgetFactory()->createLabel( vbox, "Hello, World!" );
-    YMenuButton* top = YUI::widgetFactory()->createMenuButton( vbox, "Menu!" );
-    YMenuItem *inner_item = new YMenuItem("&menu1");
-    top->addItem(inner_item);
-    top->addItem(new YMenuItem("&menu2"));
-    top->addItem(new YMenuItem("&Menu3")); // test upper letter as shortcut
-    top->addItem(new YMenuItem("menu4")); // even without shortcut marker it should find shortcut if possible
-    new YMenuItem(inner_item, "&submenu1");
-    new YMenuItem(inner_item, "&submenu2");
-    new YMenuItem(inner_item, "&submenu3");
-    new YMenuItem(inner_item, "&submenu4");
+    YUILog::setLogFileName( "/tmp/libyui-examples.log" );
+    YUILog::enableDebugLogging();
 
-    top->resolveShortcutConflicts();
-    top->rebuildMenuTree();
+    YWidgetFactory * fac = YUI::widgetFactory();
+
+    YDialog    * dialog  = fac->createPopupDialog();
+    YLayoutBox * vbox    = fac->createVBox( dialog );
+    fac->createHeading( vbox, " Menu Button Example " );
+    fac->createVSpacing( vbox, 1 );
+
+    YMenuButton * menuButton = fac->createMenuButton( vbox, "Menu" );
+    fac->createVSpacing( vbox, 2 );
+
+    YMenuItem * submenu = menuButton->addMenu( "&menu1" );
+    menuButton->addItem( "&menu2" );
+    menuButton->addItem( "&Menu3" ); // Test uppercase letter as shortcut
+    menuButton->addItem( "menu4"  ); // Even without a shortcut marker it should find a shortcut if possible
+
+    submenu->addItem( "&submenu1" );
+    submenu->addItem( "&submenu2" );
+    submenu->addSeparator();
+    submenu->addItem( "&submenu3" );
+    submenu->addItem( "&submenu4" );
+
+    menuButton->resolveShortcutConflicts();
+    menuButton->rebuildMenuTree();
 
     dialog->waitForEvent();
     dialog->destroy();

--- a/package/libyui-doc.spec
+++ b/package/libyui-doc.spec
@@ -17,10 +17,10 @@
 
 
 %define parent libyui
-%define so_version 12
+%define so_version 13
 
 Name:           %{parent}-doc
-Version:        3.10.1
+Version:        3.11.0
 Release:        0
 Source:         %{parent}-%{version}.tar.bz2
 

--- a/package/libyui.changes
+++ b/package/libyui.changes
@@ -1,3 +1,11 @@
+-------------------------------------------------------------------
+Tue Aug 11 13:26:18 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Added MenuBar widget (bsc#1175115)
+- Bumped SO version to 13
+- 3.11.0
+
+-------------------------------------------------------------------
 Fri Jun  5 12:46:43 UTC 2020 - riafarov <riafarov@suse.com>
 
 - Make itemAt method public for YSelectionWidget (bsc#1132247)

--- a/package/libyui.spec
+++ b/package/libyui.spec
@@ -16,11 +16,11 @@
 #
 
 Name:           libyui
-Version:        3.10.1
+Version:        3.11.0
 Release:        0
 Source:         %{name}-%{version}.tar.bz2
 
-%define so_version 12
+%define so_version 13
 %define bin_name %{name}%{so_version}
 
 # optionally build with code coverage reporting,

--- a/src/TreeItem.h
+++ b/src/TreeItem.h
@@ -18,7 +18,7 @@
 
   File:		TreeItem.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YAlignment.cc
+++ b/src/YAlignment.cc
@@ -18,7 +18,7 @@
 
   File:		YAlignment.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YAlignment.h
+++ b/src/YAlignment.h
@@ -18,7 +18,7 @@
 
   File:		YAlignment.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YApplication.cc
+++ b/src/YApplication.cc
@@ -18,7 +18,7 @@
 
   File:		YApplication.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YApplication.h
+++ b/src/YApplication.h
@@ -18,7 +18,7 @@
 
   File:		YApplication.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YBarGraph.cc
+++ b/src/YBarGraph.cc
@@ -18,7 +18,7 @@
 
   File:		YBarGraph.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YBarGraph.h
+++ b/src/YBarGraph.h
@@ -18,7 +18,7 @@
 
   File:		YBarGraph.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YBothDim.h
+++ b/src/YBothDim.h
@@ -18,7 +18,7 @@
 
   File:		YBothDim.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YBuiltinCaller.h
+++ b/src/YBuiltinCaller.h
@@ -18,7 +18,7 @@
 
   File:		YBuiltinCaller.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YButtonBox.cc
+++ b/src/YButtonBox.cc
@@ -18,7 +18,7 @@
 
   File:		YButtonBox.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YButtonBox.h
+++ b/src/YButtonBox.h
@@ -18,7 +18,7 @@
 
   File:		YButtonBox.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YCheckBox.cc
+++ b/src/YCheckBox.cc
@@ -18,7 +18,7 @@
 
   File:		YCheckBox.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YCheckBox.h
+++ b/src/YCheckBox.h
@@ -18,7 +18,7 @@
 
   File:		YCheckBox.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YCheckBoxFrame.cc
+++ b/src/YCheckBoxFrame.cc
@@ -18,7 +18,7 @@
 
   File:		YCheckBoxFrame.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YCheckBoxFrame.h
+++ b/src/YCheckBoxFrame.h
@@ -18,7 +18,7 @@
 
   File:		YCheckBoxFrame.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YChildrenManager.h
+++ b/src/YChildrenManager.h
@@ -18,7 +18,7 @@
 
   File:		YChildrenManager.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YColor.h
+++ b/src/YColor.h
@@ -18,7 +18,7 @@
 
   File:		YColor.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YComboBox.cc
+++ b/src/YComboBox.cc
@@ -18,7 +18,7 @@
 
   File:		YComboBox.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YComboBox.h
+++ b/src/YComboBox.h
@@ -18,7 +18,7 @@
 
   File:		YComboBox.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YCommandLine.cc
+++ b/src/YCommandLine.cc
@@ -18,7 +18,7 @@
 
   File:		YCommandLine.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YCommandLine.h
+++ b/src/YCommandLine.h
@@ -18,7 +18,7 @@
 
   File:		YCommandLine.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YContextMenu.h
+++ b/src/YContextMenu.h
@@ -18,7 +18,7 @@
 
   File:		YContextMenu.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YDateField.cc
+++ b/src/YDateField.cc
@@ -18,7 +18,7 @@
 
   File:		YDateField.cc
 
-  Author:     	Stefan Hundhammer <sh@suse.de>
+  Author:     	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YDateField.h
+++ b/src/YDateField.h
@@ -18,7 +18,7 @@
 
   File:		YDateField.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YDialog.cc
+++ b/src/YDialog.cc
@@ -18,7 +18,7 @@
 
   File:		YDialog.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YDialog.h
+++ b/src/YDialog.h
@@ -18,7 +18,7 @@
 
   File:		YDialog.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YDialogSpy.cc
+++ b/src/YDialogSpy.cc
@@ -18,7 +18,7 @@
 
   File:		YDialogSpy.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YDialogSpy.h
+++ b/src/YDialogSpy.h
@@ -18,7 +18,7 @@
 
   File:		YDialogSpy.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YDownloadProgress.cc
+++ b/src/YDownloadProgress.cc
@@ -18,7 +18,7 @@
 
   File:		YDownloadProgress.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YDownloadProgress.h
+++ b/src/YDownloadProgress.h
@@ -18,7 +18,7 @@
 
   File:		YDownloadProgress.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YDumbTab.cc
+++ b/src/YDumbTab.cc
@@ -18,7 +18,7 @@
 
   File:		YDumbTab.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YDumbTab.h
+++ b/src/YDumbTab.h
@@ -18,7 +18,7 @@
 
   File:		YDumbTab.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YEmpty.cc
+++ b/src/YEmpty.cc
@@ -18,7 +18,7 @@
 
   File:		YEmpty.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YEmpty.h
+++ b/src/YEmpty.h
@@ -18,7 +18,7 @@
 
   File:		YEmpty.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YEnvVar.cc
+++ b/src/YEnvVar.cc
@@ -18,7 +18,7 @@
 
   File:		YEnvVar.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YEnvVar.h
+++ b/src/YEnvVar.h
@@ -18,7 +18,7 @@
 
   File:		YEnvVar.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YEvent.cc
+++ b/src/YEvent.cc
@@ -18,7 +18,7 @@
 
   File:		YEvent.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YEvent.h
+++ b/src/YEvent.h
@@ -18,7 +18,7 @@
 
   File:		YEvent.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YEventFilter.cc
+++ b/src/YEventFilter.cc
@@ -18,7 +18,7 @@
 
   File:		YEventFilter.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YEventFilter.h
+++ b/src/YEventFilter.h
@@ -18,7 +18,7 @@
 
   File:		YEventFilter.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YFrame.cc
+++ b/src/YFrame.cc
@@ -18,7 +18,7 @@
 
   File:		YFrame.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YFrame.h
+++ b/src/YFrame.h
@@ -18,7 +18,7 @@
 
   File:		YFrame.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YImage.cc
+++ b/src/YImage.cc
@@ -18,7 +18,7 @@
 
   File:		YImage.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YImage.h
+++ b/src/YImage.h
@@ -18,7 +18,7 @@
 
   File:		YImage.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YInputField.cc
+++ b/src/YInputField.cc
@@ -18,7 +18,7 @@
 
   File:		YInputField.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YInputField.h
+++ b/src/YInputField.h
@@ -18,7 +18,7 @@
 
   File:		YInputField.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YIntField.cc
+++ b/src/YIntField.cc
@@ -18,7 +18,7 @@
 
   File:		YIntField.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YIntField.h
+++ b/src/YIntField.h
@@ -18,7 +18,7 @@
 
   File:		YIntField.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YItem.cc
+++ b/src/YItem.cc
@@ -18,7 +18,7 @@
 
   File:		YItem.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YItem.h
+++ b/src/YItem.h
@@ -36,8 +36,10 @@ class YItem;
 
 //! Collection of pointers to YItem.
 typedef std::vector<YItem *> 			YItemCollection;
+
 //! Mutable iterator over @ref YItemCollection.
 typedef YItemCollection::iterator		YItemIterator;
+
 //! Const   iterator over @ref YItemCollection.
 typedef YItemCollection::const_iterator		YItemConstIterator;
 

--- a/src/YItem.h
+++ b/src/YItem.h
@@ -18,7 +18,7 @@
 
   File:		YItem.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YLabel.cc
+++ b/src/YLabel.cc
@@ -18,7 +18,7 @@
 
   File:		YLabel.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YLabel.h
+++ b/src/YLabel.h
@@ -18,7 +18,7 @@
 
   File:		YLabel.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YLayoutBox.cc
+++ b/src/YLayoutBox.cc
@@ -18,7 +18,7 @@
 
   File:		YLayoutBox.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YLayoutBox.h
+++ b/src/YLayoutBox.h
@@ -18,7 +18,7 @@
 
   File:		YLayoutBox.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YLogView.cc
+++ b/src/YLogView.cc
@@ -18,7 +18,7 @@
 
   File:         YLogView.cc
 
-  Author:       Stefan Hundhammer <sh@suse.de>
+  Author:       Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YLogView.h
+++ b/src/YLogView.h
@@ -18,7 +18,7 @@
 
   File:		YLogView.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YMacro.cc
+++ b/src/YMacro.cc
@@ -18,7 +18,7 @@
 
   File:		YMacro.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YMacro.h
+++ b/src/YMacro.h
@@ -18,7 +18,7 @@
 
   File:		YMacro.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YMacroPlayer.h
+++ b/src/YMacroPlayer.h
@@ -18,7 +18,7 @@
 
   File:		YMacroPlayer.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YMacroRecorder.h
+++ b/src/YMacroRecorder.h
@@ -18,7 +18,7 @@
 
   File:		YMacroRecorder.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YMenuBar.cc
+++ b/src/YMenuBar.cc
@@ -44,6 +44,8 @@ struct YMenuBarPrivate
 };
 
 
+
+
 YMenuBar::YMenuBar( YWidget * parent )
     : YSelectionWidget( parent,
                         "",     // label
@@ -51,9 +53,10 @@ YMenuBar::YMenuBar( YWidget * parent )
     , priv( new YMenuBarPrivate() )
 {
     YUI_CHECK_NEW( priv );
+
+    setStretchable( YD_HORIZ, true );
+    setStretchable( YD_VERT,  false );
 }
-
-
 
 
 YMenuBar::~YMenuBar()
@@ -239,7 +242,7 @@ YMenuBar::findItem( std::vector<std::string>::iterator path_begin,
     {
         YMenuItem * item = dynamic_cast<YMenuItem *>(*it);
         // Test that dynamic_cast didn't fail
-        
+
         if ( !item )
             return 0;
 

--- a/src/YMenuBar.cc
+++ b/src/YMenuBar.cc
@@ -63,6 +63,15 @@ YMenuBar::~YMenuBar()
 }
 
 
+YMenuItem *
+YMenuBar::addMenu( const std::string & label,
+                   const std::string & iconName )
+{
+    YMenuItem * menu = new YMenuItem( label, iconName );
+    addItem( menu );
+
+    return menu;
+}
 
 
 const YPropertySet &

--- a/src/YMenuBar.cc
+++ b/src/YMenuBar.cc
@@ -83,9 +83,11 @@ YMenuBar::propertySet()
     {
 	/*
 	 * @property itemList	Items		All menu items and submenus
+	 * @property itemList	EnabledItems    Enabled or disabled status for items
 	 * @property string	IconPath	Base path for icons (on menu items)
 	 */
 	propSet.add( YProperty( YUIProperty_Items,		YOtherProperty	 ) );
+	propSet.add( YProperty( YUIProperty_EnabledItems,       YOtherProperty	 ) );
 	propSet.add( YProperty( YUIProperty_IconPath,		YStringProperty	 ) );
 	propSet.add( YWidget::propertySet() );
     }
@@ -100,6 +102,7 @@ YMenuBar::setProperty( const string & propertyName, const YPropertyValue & val )
     propertySet().check( propertyName, val.type() ); // throws exceptions if not found or type mismatch
 
     if      ( propertyName == YUIProperty_Items 	)	return false; // Needs special handling
+    else if ( propertyName == YUIProperty_EnabledItems 	)	return false; // Needs special handling
     else if ( propertyName == YUIProperty_IconPath 	)	setIconBasePath( val.stringVal() );
     else
     {
@@ -116,6 +119,7 @@ YMenuBar::getProperty( const string & propertyName )
     propertySet().check( propertyName ); // throws exceptions if not found
 
     if      ( propertyName == YUIProperty_Items 	)	return YPropertyValue( YOtherProperty );
+    else if ( propertyName == YUIProperty_EnabledItems 	)	return YPropertyValue( YOtherProperty );
     else if ( propertyName == YUIProperty_IconPath	)	return YPropertyValue( iconBasePath() );
     else
     {

--- a/src/YMenuBar.cc
+++ b/src/YMenuBar.cc
@@ -144,8 +144,9 @@ YMenuBar::findMenuItem( int wantedIndex,
 }
 
 
-static void resolveShortcutsConflict( YItemConstIterator begin,
-                                      YItemConstIterator end )
+void
+YMenuBar::resolveShortcutConflicts( YItemConstIterator begin,
+                                    YItemConstIterator end )
 {
     bool used[ sizeof( char ) << 8 ];
 
@@ -161,7 +162,7 @@ static void resolveShortcutsConflict( YItemConstIterator begin,
 	{
 	    if ( item->hasChildren() )
 	    {
-		resolveShortcutsConflict( item->childrenBegin(), item->childrenEnd() );
+		resolveShortcutConflicts( item->childrenBegin(), item->childrenEnd() );
 	    }
 
             char shortcut = YShortcut::normalized(YShortcut::findShortcut(item->label()));
@@ -220,7 +221,7 @@ static void resolveShortcutsConflict( YItemConstIterator begin,
 void
 YMenuBar::resolveShortcutConflicts()
 {
-    resolveShortcutsConflict( itemsBegin(), itemsEnd() );
+    resolveShortcutConflicts( itemsBegin(), itemsEnd() );
 }
 
 

--- a/src/YMenuBar.h
+++ b/src/YMenuBar.h
@@ -56,6 +56,7 @@ protected:
     YMenuBar( YWidget * parent );
 
 public:
+
     /**
      * Destructor.
      **/
@@ -99,7 +100,7 @@ public:
      *
      * @note please do not forget to call after adding all elements
      * #resolveShortcutConflicts and #rebuildMenuTree in this order. It is
-     * important to call it after all submenus are added otherwise it won't
+     * important to call it after all submenus are added, otherwise it won't
      * have proper shortcuts and won't be rendered.
      * @see examples/MenuButton.cc.
      *
@@ -179,12 +180,20 @@ public:
      **/
     YMenuItem * findMenuItem( int index );
 
+
 protected:
+
     /**
      * Check if all toplevel items are really menus, i.e. YMenuItems that have
      * children. This may throw a YUIException.
      **/
     void sanityCheck();
+
+    /**
+     * Resolve keyboard shortcut conflicts between iterators 'begin' and 'end'.
+     **/
+    void resolveShortcutConflicts( YItemConstIterator begin,
+                                   YItemConstIterator end );
 
     /**
      * Recursively find the first menu item with the specified index
@@ -220,6 +229,7 @@ protected:
      * Assign a unique index to all items from iterator 'begin' to iterator 'end'.
      **/
     void assignUniqueIndex( YItemIterator begin, YItemIterator end );
+
 
 private:
 

--- a/src/YMenuBar.h
+++ b/src/YMenuBar.h
@@ -104,15 +104,6 @@ public:
     virtual const YPropertySet & propertySet();
 
 
-protected:
-
-    /**
-     * Check if all toplevel items are really menus, i.e. YMenuItems that have
-     * children. This may throw a YUIException.
-     **/
-    void sanityCheck();
-
-
 private:
 
     ImplPtr<YMenuBarPrivate> priv;

--- a/src/YMenuBar.h
+++ b/src/YMenuBar.h
@@ -63,6 +63,12 @@ public:
     virtual ~YMenuBar();
 
     /**
+     * Create a new menu and add it.
+     **/
+    YMenuItem * addMenu( const std::string & label,
+                         const std::string & iconName = "" );
+
+    /**
      * Returns a descriptive name of this widget class for logging,
      * debugging etc.
      **/

--- a/src/YMenuBar.h
+++ b/src/YMenuBar.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (C) 2000-2012 Novell, Inc
+  Copyright (c) [2020] SUSE LLC
   This library is free software; you can redistribute it and/or modify
   it under the terms of the GNU Lesser General Public License as
   published by the Free Software Foundation; either version 2.1 of the
@@ -16,56 +16,56 @@
 
 /*-/
 
-  File:		YMenuButton.h
+  File:		YMenuBar.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 
-#ifndef YMenuButton_h
-#define YMenuButton_h
+#ifndef YMenuBar_h
+#define YMenuBar_h
 
 #include "YSelectionWidget.h"
 #include "YMenuItem.h"
 
-class YMenuButtonPrivate;
+class YMenuBarPrivate;
 
 
 /**
- * MenuButton: Similar to PushButton, but with several actions: Upon clicking
- * on a MenuButton (or activating it with the keyboard), a pop-up menu opens
- * where the user can activate an action. Menu items in that pop-up menu can
- * have submenus (that will pop up in separate pop-up menus).
+ * A classical menu bar for pulldown menus.
  *
- * Internally, this widget is more similar to the Tree widget. The difference
- * is that it does not keep a "selected" status, but triggers an action right
- * away, just like a PushButton. Like PushButton, MenuButton sends an event
- * right away when the user selects an item (clicks on a menu item or activates
- * it with the keyboard). Items that have a submenu never send an event, they
- * simply open their submenu when activated.
+ * Use this only when appropriate: In most places, YaST follows a wizard-driven
+ * UI strategy, asking the user (ideally) one question at a time, with a [Next]
+ * and a [Back] button to move between wizard steps. One of the last steps is
+ * usually presenting the collected information to the user until everything is
+ * applied.
+ *
+ * A menu bar OTOH is meant for the opposite UI strategy: Presenting some kind
+ * of document (which may also be a number of input fields) to the user as the
+ * central point and providing lots of different operations on that document.
+ * The two concepts don't mix very well, so use this widget with caution.
+ *
+ * A menu bar should only contain menus, no direct actions.
  **/
-class YMenuButton : public YSelectionWidget
+class YMenuBar: public YSelectionWidget
 {
 protected:
     /**
      * Constructor.
-     *
-     * 'label' is the user-visible text on the button (not above it like all
-     * other SelectionWidgets).
      **/
-    YMenuButton( YWidget * parent, const std::string & label );
+    YMenuBar( YWidget * parent );
 
 public:
     /**
      * Destructor.
      **/
-    virtual ~YMenuButton();
+    virtual ~YMenuBar();
 
     /**
      * Returns a descriptive name of this widget class for logging,
      * debugging etc.
      **/
-    virtual const char * widgetClass() const { return "YMenuButton"; }
+    virtual const char * widgetClass() const { return "YMenuBar"; }
 
     /**
      * Rebuild the displayed menu tree from the internally stored YMenuItems.
@@ -181,6 +181,12 @@ public:
 
 protected:
     /**
+     * Check if all toplevel items are really menus, i.e. YMenuItems that have
+     * children. This may throw a YUIException.
+     **/
+    void sanityCheck();
+
+    /**
      * Recursively find the first menu item with the specified index
      * from iterator 'begin' to iterator 'end'.
      *
@@ -210,17 +216,15 @@ protected:
     YMenuItem * itemAt( int index )
 	{ return findMenuItem( index ); }
 
-
     /**
      * Assign a unique index to all items from iterator 'begin' to iterator 'end'.
      **/
     void assignUniqueIndex( YItemIterator begin, YItemIterator end );
 
-    
 private:
 
-    ImplPtr<YMenuButtonPrivate> priv;
+    ImplPtr<YMenuBarPrivate> priv;
 };
 
 
-#endif // YMenuButton_h
+#endif  // YMenuBar_h

--- a/src/YMenuBar.h
+++ b/src/YMenuBar.h
@@ -25,7 +25,7 @@
 #ifndef YMenuBar_h
 #define YMenuBar_h
 
-#include "YSelectionWidget.h"
+#include "YMenuWidget.h"
 #include "YMenuItem.h"
 
 class YMenuBarPrivate;
@@ -47,7 +47,7 @@ class YMenuBarPrivate;
  *
  * A menu bar should only contain menus, no direct actions.
  **/
-class YMenuBar: public YSelectionWidget
+class YMenuBar: public YMenuWidget
 {
 protected:
     /**
@@ -67,62 +67,6 @@ public:
      * debugging etc.
      **/
     virtual const char * widgetClass() const { return "YMenuBar"; }
-
-    /**
-     * Rebuild the displayed menu tree from the internally stored YMenuItems.
-     *
-     * The application should call this (once) after all items have been added
-     * with addItem(). YMenuButton::addItems() calls this automatically.
-     *
-     * Derived classes are required to implement this.
-     **/
-    virtual void rebuildMenuTree() = 0;
-
-    /**
-     * Add multiple items. For some UIs, this can be more efficient than
-     * calling addItem() multiple times. This function also automatically calls
-     * resolveShortcutConflicts() and rebuildMenuTree() at the end.
-     *
-     * Derived classes can overwrite this function, but they should call this
-     * base class function at the end of the new implementation.
-     *
-     * Reimplemented from YSelectionWidget.
-     **/
-    virtual void addItems( const YItemCollection & itemCollection );
-
-    /**
-     * Add one item. This widget assumes ownership of the item object and will
-     * delete it in its destructor.
-     *
-     * This reimplementation will an index to the item that is unique for all
-     * items in this MenuButton. That index can be used later with
-     * findMenuItem() to find the item by that index.
-     *
-     * @note please do not forget to call after adding all elements
-     * #resolveShortcutConflicts and #rebuildMenuTree in this order. It is
-     * important to call it after all submenus are added, otherwise it won't
-     * have proper shortcuts and won't be rendered.
-     * @see examples/MenuButton.cc.
-     *
-     * Reimplemented from YSelectionWidget.
-     **/
-    virtual void addItem( YItem * item_disown );
-
-    /**
-     * Delete all items.
-     *
-     * Reimplemented from YSelectionWidget.
-     **/
-    virtual void deleteAllItems();
-
-    /**
-     * Resolve keyboard shortcut conflicts: Change shortcuts of menu items if
-     * there are duplicates in the respective menu level.
-     *
-     * This has to be called after all items are added, but before rebuildMenuTree()
-     * (see above). YMenuButton::addItems() calls this automatically.
-     **/
-    void resolveShortcutConflicts();
 
     /**
      * Set a property.
@@ -153,33 +97,6 @@ public:
      **/
     virtual const YPropertySet & propertySet();
 
-    /**
-     * Support for the Rest API for UI testing:
-     *
-     * Return the item in the tree which matches a path of labels. This
-     * returns 0 if there is no such item or if it is not a leaf menu item.
-     *
-     * 'path' specifies the user-visible labels (i.e. the translated texts) of
-     * each menu level ( ["File", "Export", "As XML"] ).
-     **/
-    YMenuItem * findItem( std::vector<std::string> & path ) const;
-
-    /**
-     * Support for the Rest API for UI testing:
-     *
-     * Activate the item selected in the tree.
-     * This can be used in tests to simulate user input.
-     *
-     * Derived classes are required to implement this.
-     **/
-    virtual void activateItem( YMenuItem * item ) = 0;
-
-    /**
-     * Recursively find the first menu item with the specified index.
-     * Returns 0 if there is no such item.
-     **/
-    YMenuItem * findMenuItem( int index );
-
 
 protected:
 
@@ -188,47 +105,6 @@ protected:
      * children. This may throw a YUIException.
      **/
     void sanityCheck();
-
-    /**
-     * Resolve keyboard shortcut conflicts between iterators 'begin' and 'end'.
-     **/
-    void resolveShortcutConflicts( YItemConstIterator begin,
-                                   YItemConstIterator end );
-
-    /**
-     * Recursively find the first menu item with the specified index
-     * from iterator 'begin' to iterator 'end'.
-     *
-     * Returns 0 if there is no such item.
-     **/
-    YMenuItem * findMenuItem( int                index,
-                              YItemConstIterator begin,
-                              YItemConstIterator end );
-
-    /**
-     * Recursively looks for the first item in the tree of the menu items
-     * using depth first search.
-     * Return nullptr if item which matches full path is not found.
-     * Path is a vector of strings, where next element is a child item, so
-     * in case one needs to select File->Export->As PDF, for instance,
-     * Vector will look like [ "File", "Export", "As PDF" ].
-     */
-    YMenuItem * findItem( std::vector<std::string>::iterator path_begin,
-                          std::vector<std::string>::iterator path_end,
-                          YItemConstIterator                 begin,
-                          YItemConstIterator                 end ) const;
-
-    /**
-     * Alias for findMenuItem(). Reimplemented to ensure consistent behaviour
-     * with YSelectionWidget::itemAt().
-     **/
-    YMenuItem * itemAt( int index )
-	{ return findMenuItem( index ); }
-
-    /**
-     * Assign a unique index to all items from iterator 'begin' to iterator 'end'.
-     **/
-    void assignUniqueIndex( YItemIterator begin, YItemIterator end );
 
 
 private:

--- a/src/YMenuButton.cc
+++ b/src/YMenuButton.cc
@@ -37,18 +37,16 @@ using std::string;
 struct YMenuButtonPrivate
 {
     YMenuButtonPrivate()
-	: nextSerialNo( 0 )
 	{}
 
-    int nextSerialNo;
+    int dummy;
 };
 
 
 
 
 YMenuButton::YMenuButton( YWidget * parent, const string & label )
-    : YSelectionWidget( parent, label,
-			false )	// enforceSingleSelection
+    : YMenuWidget( parent, label )
     , priv( new YMenuButtonPrivate() )
 {
     YUI_CHECK_NEW( priv );
@@ -58,206 +56,6 @@ YMenuButton::YMenuButton( YWidget * parent, const string & label )
 YMenuButton::~YMenuButton()
 {
     // NOP
-}
-
-
-void
-YMenuButton::addItems( const YItemCollection & itemCollection )
-{
-    YSelectionWidget::addItems( itemCollection );
-    resolveShortcutConflicts();
-    rebuildMenuTree();
-}
-
-
-void
-YMenuButton::addItem( YItem * item )
-{
-    YSelectionWidget::addItem( item );
-    item->setIndex( ++(priv->nextSerialNo) );
-
-    if ( item->hasChildren() )
-	assignUniqueIndex( item->childrenBegin(), item->childrenEnd() );
-}
-
-
-void
-YMenuButton::assignUniqueIndex( YItemIterator begin, YItemIterator end )
-{
-    for ( YItemIterator it = begin; it != end; ++it )
-    {
-	YItem * item = *it;
-
-	item->setIndex( ++(priv->nextSerialNo) );
-
-	if ( item->hasChildren() )
-	    assignUniqueIndex( item->childrenBegin(), item->childrenEnd() );
-    }
-}
-
-
-void
-YMenuButton::deleteAllItems()
-{
-    YSelectionWidget::deleteAllItems();
-    priv->nextSerialNo = 0;
-}
-
-
-YMenuItem *
-YMenuButton::findMenuItem( int index )
-{
-    return findMenuItem( index, itemsBegin(), itemsEnd() );
-}
-
-
-YMenuItem *
-YMenuButton::findMenuItem( int wantedIndex, YItemConstIterator begin, YItemConstIterator end )
-{
-    for ( YItemConstIterator it = begin; it != end; ++it )
-    {
-	YMenuItem * item = dynamic_cast<YMenuItem *> (*it);
-
-	if ( item )
-	{
-	    if ( item->index() == wantedIndex )
-		return item;
-
-	    if ( item->hasChildren() )
-	    {
-		YMenuItem * result = findMenuItem( wantedIndex, item->childrenBegin(), item->childrenEnd() );
-
-		if ( result )
-		    return result;
-	    }
-	}
-    }
-
-    return 0;
-}
-
-
-void
-YMenuButton::resolveShortcutConflicts( YItemConstIterator begin, YItemConstIterator end )
-{
-    bool used[ sizeof( char ) << 8 ];
-
-    for ( unsigned i=0; i < sizeof( char ) << 8; i++ )
-	used[i] = false;
-    std::vector<YMenuItem*> conflicts;
-
-    for ( YItemConstIterator it = begin; it != end; ++it )
-    {
-	YMenuItem * item = dynamic_cast<YMenuItem *> (*it);
-
-	if ( item )
-	{
-	    if ( item->hasChildren() )
-	    {
-		resolveShortcutConflicts( item->childrenBegin(), item->childrenEnd() );
-	    }
-
-            char shortcut = YShortcut::normalized(YShortcut::findShortcut(item->label()));
-
-            if ( shortcut == 0 )
-            {
-                conflicts.push_back(item);
-                yuiMilestone() << "No or invalid shortcut found " << item->label() << endl;
-            }
-            else if ( used[ (unsigned)shortcut ] )
-            {
-                conflicts.push_back(item);
-                yuiWarning() << "Conflicting shortcut found " << item->label() << endl;
-            }
-            else
-            {
-                used[ (unsigned) shortcut ] = true;
-            }
-	}
-        else
-        {
-            yuiWarning() << "non menu item used in call " << (*it)->label() << endl;
-        }
-    }
-
-    // cannot use YShortcut directly as an YItem is not a YWidget
-    for( YMenuItem *i: conflicts )
-    {
-        string clean = YShortcut::cleanShortcutString(i->label());
-        char new_c = 0;
-
-        size_t index = 0;
-        for (; index < clean.size(); ++index)
-        {
-            char ch = YShortcut::normalized( clean[index] );
-            // ch is set to 0 by normalized() if not valid
-            if ( ch != 0 && ! used[ (unsigned)ch ] )
-            {
-                new_c = ch;
-                used[(unsigned)ch] = true;
-                break;
-            }
-        }
-
-        if (new_c != 0)
-        {
-            clean.insert(index, 1, YShortcut::shortcutMarker());
-            yuiMilestone() << "New label used: " << clean << endl;
-        }
-
-        i->setLabel( clean );
-    }
-}
-
-
-void
-YMenuButton::resolveShortcutConflicts()
-{
-    resolveShortcutConflicts( itemsBegin(), itemsEnd() );
-}
-
-
-YMenuItem *
-YMenuButton::findItem( std::vector<std::string> & path ) const
-{
-    return findItem( path.begin(), path.end(),
-                     itemsBegin(), itemsEnd() );
-}
-
-
-YMenuItem *
-YMenuButton::findItem( std::vector<std::string>::iterator path_begin,
-                       std::vector<std::string>::iterator path_end,
-                       YItemConstIterator begin,
-                       YItemConstIterator end ) const
-{
-    for ( YItemConstIterator it = begin; it != end; ++it )
-    {
-        YMenuItem * item = dynamic_cast<YMenuItem *>(*it);
-        // Test that dynamic_cast didn't fail
-        if ( !item )
-            return nullptr;
-
-        if ( item->label() == *path_begin )
-        {
-            if ( std::next(path_begin) == path_end )
-            {
-                // Only return items which can trigger an action.
-                // Intermediate items only open a submenu, so continue looking.
-
-                if( item->hasChildren() )
-                    continue;
-
-                return item;
-            }
-
-            // Look in child nodes and return if found one
-            YMenuItem * result = findItem( ++path_begin, path_end, item->childrenBegin(), item->childrenEnd() );
-            if ( result )
-                return result;
-        }
-    }
-    return nullptr;
 }
 
 

--- a/src/YMenuButton.cc
+++ b/src/YMenuButton.cc
@@ -29,7 +29,6 @@
 #include "YUISymbols.h"
 #include "YMenuButton.h"
 #include "YMenuItem.h"
-#include "YShortcut.h"
 
 using std::string;
 
@@ -56,6 +55,38 @@ YMenuButton::YMenuButton( YWidget * parent, const string & label )
 YMenuButton::~YMenuButton()
 {
     // NOP
+}
+
+
+YMenuItem *
+YMenuButton::addItem( const std::string & label,
+                      const std::string & iconName )
+{
+    YMenuItem * item = new YMenuItem( label, iconName );
+    YMenuWidget::addItem( item );
+
+    return item;
+}
+
+
+YMenuItem *
+YMenuButton::addMenu( const std::string & label,
+                      const std::string & iconName )
+{
+    YMenuItem * menu = new YMenuItem( label, iconName );
+    YMenuWidget::addItem( menu );
+
+    return menu;
+}
+
+
+YMenuItem *
+YMenuButton::addSeparator()
+{
+    YMenuItem * separator = new YMenuItem( "" );
+    YMenuWidget::addItem( separator );
+
+    return separator;
 }
 
 

--- a/src/YMenuButton.cc
+++ b/src/YMenuButton.cc
@@ -18,7 +18,7 @@
 
   File:		YMenuButton.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YMenuButton.cc
+++ b/src/YMenuButton.cc
@@ -136,9 +136,11 @@ YMenuButton::findMenuItem( int wantedIndex, YItemConstIterator begin, YItemConst
     return 0;
 }
 
-static void resolveShortcutsConflictFlat(YItemConstIterator begin, YItemConstIterator end)
+
+static void resolveShortcutsConflictFlat( YItemConstIterator begin, YItemConstIterator end )
 {
     bool used[ sizeof( char ) << 8 ];
+
     for ( unsigned i=0; i < sizeof( char ) << 8; i++ )
 	used[i] = false;
     std::vector<YMenuItem*> conflicts;
@@ -151,34 +153,34 @@ static void resolveShortcutsConflictFlat(YItemConstIterator begin, YItemConstIte
 	{
 	    if ( item->hasChildren() )
 	    {
-		resolveShortcutsConflictFlat(item->childrenBegin(), item->childrenEnd() );
+		resolveShortcutsConflictFlat( item->childrenBegin(), item->childrenEnd() );
 	    }
 
             char shortcut = YShortcut::normalized(YShortcut::findShortcut(item->label()));
 
-            if (shortcut == 0)
+            if ( shortcut == 0 )
             {
                 conflicts.push_back(item);
                 yuiMilestone() << "No or invalid shortcut found " << item->label() << endl;
             }
-            else if (used[(unsigned)shortcut])
+            else if ( used[ (unsigned)shortcut ] )
             {
                 conflicts.push_back(item);
                 yuiWarning() << "Conflicting shortcut found " << item->label() << endl;
             }
             else
             {
-                used[(unsigned)shortcut] = true;
+                used[ (unsigned) shortcut ] = true;
             }
 	}
         else
         {
-          yuiWarning() << "non menu item used in call " << (*it)->label() << endl;
+            yuiWarning() << "non menu item used in call " << (*it)->label() << endl;
         }
     }
 
-    // cannot use YShortcut directly as YItem is not YWidget
-    for(YMenuItem *i: conflicts)
+    // cannot use YShortcut directly as an YItem is not a YWidget
+    for( YMenuItem *i: conflicts )
     {
         string clean = YShortcut::cleanShortcutString(i->label());
         char new_c = 0;
@@ -186,9 +188,9 @@ static void resolveShortcutsConflictFlat(YItemConstIterator begin, YItemConstIte
         size_t index = 0;
         for (; index < clean.size(); ++index)
         {
-            char ch = YShortcut::normalized(clean[index]);
-            // ch is set to 0 by normalized if not valid
-            if (ch != 0 && !used[(unsigned)ch])
+            char ch = YShortcut::normalized( clean[index] );
+            // ch is set to 0 by normalized() if not valid
+            if ( ch != 0 && ! used[ (unsigned)ch ] )
             {
                 new_c = ch;
                 used[(unsigned)ch] = true;
@@ -201,14 +203,16 @@ static void resolveShortcutsConflictFlat(YItemConstIterator begin, YItemConstIte
             clean.insert(index, 1, YShortcut::shortcutMarker());
             yuiMilestone() << "New label used: " << clean << endl;
         }
-        i->setLabel(clean);
+
+        i->setLabel( clean );
     }
 }
+
 
 void
 YMenuButton::resolveShortcutConflicts()
 {
-    resolveShortcutsConflictFlat(itemsBegin(), itemsEnd());
+    resolveShortcutsConflictFlat( itemsBegin(), itemsEnd() );
 }
 
 

--- a/src/YMenuButton.cc
+++ b/src/YMenuButton.cc
@@ -137,7 +137,8 @@ YMenuButton::findMenuItem( int wantedIndex, YItemConstIterator begin, YItemConst
 }
 
 
-static void resolveShortcutsConflictFlat( YItemConstIterator begin, YItemConstIterator end )
+void
+YMenuButton::resolveShortcutConflicts( YItemConstIterator begin, YItemConstIterator end )
 {
     bool used[ sizeof( char ) << 8 ];
 
@@ -153,7 +154,7 @@ static void resolveShortcutsConflictFlat( YItemConstIterator begin, YItemConstIt
 	{
 	    if ( item->hasChildren() )
 	    {
-		resolveShortcutsConflictFlat( item->childrenBegin(), item->childrenEnd() );
+		resolveShortcutConflicts( item->childrenBegin(), item->childrenEnd() );
 	    }
 
             char shortcut = YShortcut::normalized(YShortcut::findShortcut(item->label()));
@@ -212,7 +213,7 @@ static void resolveShortcutsConflictFlat( YItemConstIterator begin, YItemConstIt
 void
 YMenuButton::resolveShortcutConflicts()
 {
-    resolveShortcutsConflictFlat( itemsBegin(), itemsEnd() );
+    resolveShortcutConflicts( itemsBegin(), itemsEnd() );
 }
 
 
@@ -243,13 +244,13 @@ YMenuButton::findItem( std::vector<std::string>::iterator path_begin,
             {
                 // Only return items which can trigger an action.
                 // Intermediate items only open a submenu, so continue looking.
-                
+
                 if( item->hasChildren() )
                     continue;
 
                 return item;
             }
-            
+
             // Look in child nodes and return if found one
             YMenuItem * result = findItem( ++path_begin, path_end, item->childrenBegin(), item->childrenEnd() );
             if ( result )

--- a/src/YMenuButton.h
+++ b/src/YMenuButton.h
@@ -25,7 +25,7 @@
 #ifndef YMenuButton_h
 #define YMenuButton_h
 
-#include "YSelectionWidget.h"
+#include "YMenuWidget.h"
 #include "YMenuItem.h"
 
 class YMenuButtonPrivate;
@@ -44,7 +44,7 @@ class YMenuButtonPrivate;
  * it with the keyboard). Items that have a submenu never send an event, they
  * simply open their submenu when activated.
  **/
-class YMenuButton : public YSelectionWidget
+class YMenuButton : public YMenuWidget
 {
 protected:
     /**
@@ -67,62 +67,6 @@ public:
      * debugging etc.
      **/
     virtual const char * widgetClass() const { return "YMenuButton"; }
-
-    /**
-     * Rebuild the displayed menu tree from the internally stored YMenuItems.
-     *
-     * The application should call this (once) after all items have been added
-     * with addItem(). YMenuButton::addItems() calls this automatically.
-     *
-     * Derived classes are required to implement this.
-     **/
-    virtual void rebuildMenuTree() = 0;
-
-    /**
-     * Add multiple items. For some UIs, this can be more efficient than
-     * calling addItem() multiple times. This function also automatically calls
-     * resolveShortcutConflicts() and rebuildMenuTree() at the end.
-     *
-     * Derived classes can overwrite this function, but they should call this
-     * base class function at the end of the new implementation.
-     *
-     * Reimplemented from YSelectionWidget.
-     **/
-    virtual void addItems( const YItemCollection & itemCollection );
-
-    /**
-     * Add one item. This widget assumes ownership of the item object and will
-     * delete it in its destructor.
-     *
-     * This reimplementation will an index to the item that is unique for all
-     * items in this MenuButton. That index can be used later with
-     * findMenuItem() to find the item by that index.
-     *
-     * @note please do not forget to call after adding all elements
-     * #resolveShortcutConflicts and #rebuildMenuTree in this order. It is
-     * important to call it after all submenus are added otherwise it won't
-     * have proper shortcuts and won't be rendered.
-     * @see examples/MenuButton.cc.
-     *
-     * Reimplemented from YSelectionWidget.
-     **/
-    virtual void addItem( YItem * item_disown );
-
-    /**
-     * Delete all items.
-     *
-     * Reimplemented from YSelectionWidget.
-     **/
-    virtual void deleteAllItems();
-
-    /**
-     * Resolve keyboard shortcut conflicts: Change shortcuts of menu items if
-     * there are duplicates in the respective menu level.
-     *
-     * This has to be called after all items are added, but before rebuildMenuTree()
-     * (see above). YMenuButton::addItems() calls this automatically.
-     **/
-    void resolveShortcutConflicts();
 
     /**
      * Set a property.
@@ -152,78 +96,6 @@ public:
      * Reimplemented from YWidget.
      **/
     virtual const YPropertySet & propertySet();
-
-    /**
-     * Support for the Rest API for UI testing:
-     *
-     * Return the item in the tree which matches a path of labels. This
-     * returns 0 if there is no such item or if it is not a leaf menu item.
-     *
-     * 'path' specifies the user-visible labels (i.e. the translated texts) of
-     * each menu level ( ["File", "Export", "As XML"] ).
-     **/
-    YMenuItem * findItem( std::vector<std::string> & path ) const;
-
-    /**
-     * Support for the Rest API for UI testing:
-     *
-     * Activate the item selected in the tree.
-     * This can be used in tests to simulate user input.
-     *
-     * Derived classes are required to implement this.
-     **/
-    virtual void activateItem( YMenuItem * item ) = 0;
-
-    /**
-     * Recursively find the first menu item with the specified index.
-     * Returns 0 if there is no such item.
-     **/
-    YMenuItem * findMenuItem( int index );
-
-
-protected:
-
-    /**
-     * Resolve keyboard shortcut conflicts between iterators 'begin' and 'end'.
-     **/
-    void resolveShortcutConflicts( YItemConstIterator begin,
-                                   YItemConstIterator end );
-
-    /**
-     * Recursively find the first menu item with the specified index
-     * from iterator 'begin' to iterator 'end'.
-     *
-     * Returns 0 if there is no such item.
-     **/
-    YMenuItem * findMenuItem( int                index,
-                              YItemConstIterator begin,
-                              YItemConstIterator end );
-
-    /**
-     * Recursively looks for the first item in the tree of the menu items
-     * using depth first search.
-     * Return nullptr if item which matches full path is not found.
-     * Path is a vector of strings, where next element is a child item, so
-     * in case one needs to select File->Export->As PDF, for instance,
-     * Vector will look like [ "File", "Export", "As PDF" ].
-     */
-    YMenuItem * findItem( std::vector<std::string>::iterator path_begin,
-                          std::vector<std::string>::iterator path_end,
-                          YItemConstIterator                 begin,
-                          YItemConstIterator                 end ) const;
-
-    /**
-     * Alias for findMenuItem(). Reimplemented to ensure consistent behaviour
-     * with YSelectionWidget::itemAt().
-     **/
-    YMenuItem * itemAt( int index )
-	{ return findMenuItem( index ); }
-
-
-    /**
-     * Assign a unique index to all items from iterator 'begin' to iterator 'end'.
-     **/
-    void assignUniqueIndex( YItemIterator begin, YItemIterator end );
 
 
 private:

--- a/src/YMenuButton.h
+++ b/src/YMenuButton.h
@@ -63,6 +63,23 @@ public:
     virtual ~YMenuButton();
 
     /**
+     * Create a new menu item and add it.
+     **/
+    YMenuItem * addItem( const std::string & label,
+                         const std::string & iconName = "" );
+
+    /**
+     * Create a new submenu and add it.
+     **/
+    YMenuItem * addMenu( const std::string & label,
+                         const std::string & iconName = "" );
+
+    /**
+     * Create a new menu separator and add it.
+     **/
+    YMenuItem * addSeparator();
+
+    /**
      * Returns a descriptive name of this widget class for logging,
      * debugging etc.
      **/

--- a/src/YMenuButton.h
+++ b/src/YMenuButton.h
@@ -18,7 +18,7 @@
 
   File:		YMenuButton.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YMenuButton.h
+++ b/src/YMenuButton.h
@@ -56,6 +56,7 @@ protected:
     YMenuButton( YWidget * parent, const std::string & label );
 
 public:
+
     /**
      * Destructor.
      **/
@@ -179,7 +180,15 @@ public:
      **/
     YMenuItem * findMenuItem( int index );
 
+
 protected:
+
+    /**
+     * Resolve keyboard shortcut conflicts between iterators 'begin' and 'end'.
+     **/
+    void resolveShortcutConflicts( YItemConstIterator begin,
+                                   YItemConstIterator end );
+
     /**
      * Recursively find the first menu item with the specified index
      * from iterator 'begin' to iterator 'end'.
@@ -216,7 +225,7 @@ protected:
      **/
     void assignUniqueIndex( YItemIterator begin, YItemIterator end );
 
-    
+
 private:
 
     ImplPtr<YMenuButtonPrivate> priv;

--- a/src/YMenuItem.cc
+++ b/src/YMenuItem.cc
@@ -1,0 +1,46 @@
+/*
+  Copyright (c) [2020] SUSE LLC
+  This library is free software; you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as
+  published by the Free Software Foundation; either version 2.1 of the
+  License, or (at your option) version 3.0 of the License. This library
+  is distributed in the hope that it will be useful, but WITHOUT ANY
+  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+  FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+  License for more details. You should have received a copy of the GNU
+  Lesser General Public License along with this library; if not, write
+  to the Free Software Foundation, Inc., 51 Franklin Street, Fifth
+  Floor, Boston, MA 02110-1301 USA
+*/
+
+
+/*-/
+
+  File:		YMenuItem.cc
+
+  Author:	Stefan Hundhammer <sh@suse.de>
+
+/-*/
+
+
+#include "YMenuItem.h"
+
+
+YMenuItem * YMenuItem::addItem( const std::string & label,
+                                const std::string & iconName )
+{
+    return new YMenuItem( this, label, iconName );
+}
+
+
+YMenuItem * YMenuItem::addMenu( const std::string & label,
+                                const std::string & iconName )
+{
+    return new YMenuItem( this, label, iconName );
+}
+
+
+YMenuItem * YMenuItem::addSeparator()
+{
+    return new YMenuItem( this, "" );
+}

--- a/src/YMenuItem.cc
+++ b/src/YMenuItem.cc
@@ -18,7 +18,7 @@
 
   File:		YMenuItem.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YMenuItem.h
+++ b/src/YMenuItem.h
@@ -1,5 +1,6 @@
 /*
-  Copyright (C) 2000-2012 Novell, Inc
+  Copyright (C) 2000-2018 Novell, Inc
+  Copyright (c) [2019-2020] SUSE LLC
   This library is free software; you can redistribute it and/or modify
   it under the terms of the GNU Lesser General Public License as
   published by the Free Software Foundation; either version 2.1 of the
@@ -31,19 +32,22 @@
 
 /**
  * Item class for menu items.
+ *
+ * This is used for plain menu items as well as for menus as well as for menu
+ * separators:
+ *
+ * A menu is a menu item with child items.
+ * A plain menu item does not have child items.
+ * A menu separator has an empty label.
  **/
 class YMenuItem: public YTreeItem
 {
 public:
     /**
-     * Constructors for toplevel items.
+     * Constructor for toplevel items.
      **/
-    YMenuItem( const std::string &	label )
-	: YTreeItem( label )
-	{}
-
     YMenuItem( const std::string & 	label,
-	       const std::string & 	iconName )
+	       const std::string & 	iconName = "" )
 	: YTreeItem( label, iconName )
 	{}
 
@@ -53,17 +57,15 @@ public:
      * They will automatically register this item with the parent item. The
      * parent assumes ownership of this item and will delete it in its (the
      * parent's) destructor.
+     *
+     * Consider using addItem() or addMenu() instead.
      **/
     YMenuItem( YMenuItem *		parent,
-	       const std::string & 	label )
-	: YTreeItem( parent, label )
-	{}
-
-    YMenuItem( YMenuItem *		parent,
 	       const std::string & 	label,
-	       const std::string & 	iconName )
+	       const std::string & 	iconName = "" )
 	: YTreeItem( parent, label, iconName )
 	{}
+
 
     /**
      * Destructor.
@@ -72,12 +74,51 @@ public:
      **/
     virtual ~YMenuItem() {}
 
+    /**
+     * Create a new menu item as a child of the current instance and return it.
+     * The newly created object is owned by this instance.
+     * This is meant for plain menu items, not for submenus.
+     **/
+    YMenuItem * addItem( const std::string & label,
+                         const std::string & iconName = "" );
+
+    /**
+     * Create a new submenu as a child of the current instance and return it.
+     * The newly created object is owned by this instance.
+     * This is meant to be used for menu items that have children.
+     **/
+    YMenuItem * addMenu( const std::string & label,
+                         const std::string & iconName = "" );
+
+    /**
+     * Create a menu separator as a child of the current instance and return it.
+     * The newly created object is owned by this instance.
+     **/
+    YMenuItem * addSeparator();
 
     /**
      * Returns this item's parent item or 0 if it is a toplevel item.
      **/
     YMenuItem * parent() const
 	{ return dynamic_cast<YMenuItem *> ( YTreeItem::parent() ); }
+
+    /**
+     * Return 'true' if this is a menu (or submenu), i.e. if it has any child
+     * items.
+     **/
+    bool isMenu() const { return hasChildren(); }
+
+    /**
+     * Return 'true' if this is a menu separator, i.e. if it has an empty label.
+     **/
+    bool isSeparator() const { return label().empty(); }
+
+    /**
+     * Create a menu separator item and return it. The new separator is owned
+     * by 'parent'.
+     **/
+    static YMenuItem * createSeparator( YMenuItem * parent)
+        { return new YMenuItem( parent, "" ); }
 
 
 private:

--- a/src/YMenuItem.h
+++ b/src/YMenuItem.h
@@ -19,7 +19,7 @@
 
   File:		YMenuItem.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YMenuItem.h
+++ b/src/YMenuItem.h
@@ -49,6 +49,8 @@ public:
     YMenuItem( const std::string & 	label,
 	       const std::string & 	iconName = "" )
 	: YTreeItem( label, iconName )
+        , _enabled( true )
+        , _uiItem( 0 )
 	{}
 
     /**
@@ -64,6 +66,8 @@ public:
 	       const std::string & 	label,
 	       const std::string & 	iconName = "" )
 	: YTreeItem( parent, label, iconName )
+        , _enabled( true )
+        , _uiItem( 0 )
 	{}
 
 
@@ -114,11 +118,30 @@ public:
     bool isSeparator() const { return label().empty(); }
 
     /**
-     * Create a menu separator item and return it. The new separator is owned
-     * by 'parent'.
+     * Return 'true' if this item is enabled (which is the default).
      **/
-    static YMenuItem * createSeparator( YMenuItem * parent)
-        { return new YMenuItem( parent, "" ); }
+    bool isEnabled() const { return _enabled; }
+
+    /**
+     * Enable or disable this item.
+     *
+     * Applications should use YMenuWidget::setItemEnabled() instead because
+     * that will also notify the widget so it can update the item's visual
+     * representation.
+     **/
+    void setEnabled( bool enabled = true ) { _enabled = enabled; }
+
+    /**
+     * Return the UI counterpart of this item (if the UI set any).
+     **/
+    void * uiItem() const { return _uiItem; }
+
+    /**
+     * Set the UI counterpart of this item. This can be used to store a pointer
+     * to the equivalent of this item in the concrete UI: For example, the Qt
+     * UI will store a pointer to the corresponding QMenu or QAction.
+     **/
+    void setUiItem( void * uiItem ) { _uiItem = uiItem; }
 
 
 private:
@@ -127,6 +150,12 @@ private:
 
     bool isOpen() const  { return false; }
     void setOpen( bool ) {}
+
+
+    // Data members
+
+    bool   _enabled;
+    void * _uiItem;
 };
 
 

--- a/src/YMenuWidget.cc
+++ b/src/YMenuWidget.cc
@@ -281,7 +281,7 @@ YMenuWidget::findItem( std::vector<std::string>::iterator path_begin,
                 return item;
             }
 
-            // Look in child nodes and return if found one
+            // Look in child nodes
             YMenuItem * result = findItem( ++path_begin, path_end,
                                            item->childrenBegin(), item->childrenEnd() );
             if ( result )

--- a/src/YMenuWidget.cc
+++ b/src/YMenuWidget.cc
@@ -1,0 +1,319 @@
+/*
+  Copyright (c) [2020] SUSE LLC
+  This library is free software; you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as
+  published by the Free Software Foundation; either version 2.1 of the
+  License, or (at your option) version 3.0 of the License. This library
+  is distributed in the hope that it will be useful, but WITHOUT ANY
+  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+  FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+  License for more details. You should have received a copy of the GNU
+  Lesser General Public License along with this library; if not, write
+  to the Free Software Foundation, Inc., 51 Franklin Street, Fifth
+  Floor, Boston, MA 02110-1301 USA
+*/
+
+
+/*-/
+
+  File:		YMenuWidget.cc
+
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
+
+/-*/
+
+
+#define YUILogComponent "ui"
+#include "YUILog.h"
+
+#include "YUISymbols.h"
+#include "YShortcut.h"
+#include "YMenuWidget.h"
+
+
+using std::string;
+
+
+struct YMenuWidgetPrivate
+{
+    YMenuWidgetPrivate()
+	: nextSerialNo( 0 )
+	{}
+
+    int nextSerialNo;
+};
+
+
+
+
+YMenuWidget::YMenuWidget( YWidget * parent, const string & label )
+    : YSelectionWidget( parent,
+                        label,
+			false )	// enforceSingleSelection
+    , priv( new YMenuWidgetPrivate() )
+{
+    YUI_CHECK_NEW( priv );
+}
+
+
+YMenuWidget::~YMenuWidget()
+{
+    // NOP
+}
+
+
+void
+YMenuWidget::addItems( const YItemCollection & itemCollection )
+{
+    YSelectionWidget::addItems( itemCollection );
+    resolveShortcutConflicts();
+    rebuildMenuTree();
+}
+
+
+void
+YMenuWidget::addItem( YItem * item )
+{
+    YSelectionWidget::addItem( item );
+    item->setIndex( ++(priv->nextSerialNo) );
+
+    if ( item->hasChildren() )
+	assignUniqueIndex( item->childrenBegin(), item->childrenEnd() );
+}
+
+
+void
+YMenuWidget::assignUniqueIndex( YItemIterator begin, YItemIterator end )
+{
+    for ( YItemIterator it = begin; it != end; ++it )
+    {
+	YItem * item = *it;
+
+	item->setIndex( ++(priv->nextSerialNo) );
+
+	if ( item->hasChildren() )
+	    assignUniqueIndex( item->childrenBegin(), item->childrenEnd() );
+    }
+}
+
+
+void
+YMenuWidget::deleteAllItems()
+{
+    YSelectionWidget::deleteAllItems();
+    priv->nextSerialNo = 0;
+}
+
+
+YMenuItem *
+YMenuWidget::findMenuItem( int index )
+{
+    return findMenuItem( index, itemsBegin(), itemsEnd() );
+}
+
+
+YMenuItem *
+YMenuWidget::findMenuItem( int wantedIndex,
+                        YItemConstIterator begin,
+                        YItemConstIterator end )
+{
+    for ( YItemConstIterator it = begin; it != end; ++it )
+    {
+	YMenuItem * item = dynamic_cast<YMenuItem *> (*it);
+
+	if ( item )
+	{
+	    if ( item->index() == wantedIndex )
+		return item;
+
+	    if ( item->hasChildren() )
+	    {
+		YMenuItem * result = findMenuItem( wantedIndex,
+                                                   item->childrenBegin(),
+                                                   item->childrenEnd() );
+		if ( result )
+		    return result;
+	    }
+	}
+    }
+
+    return 0;
+}
+
+
+void
+YMenuWidget::resolveShortcutConflicts( YItemConstIterator begin,
+                                    YItemConstIterator end )
+{
+    bool used[ sizeof( char ) << 8 ];
+
+    for ( unsigned i=0; i < sizeof( char ) << 8; i++ )
+	used[i] = false;
+    std::vector<YMenuItem*> conflicts;
+
+    for ( YItemConstIterator it = begin; it != end; ++it )
+    {
+	YMenuItem * item = dynamic_cast<YMenuItem *> (*it);
+
+	if ( item )
+	{
+	    if ( item->hasChildren() )
+	    {
+		resolveShortcutConflicts( item->childrenBegin(), item->childrenEnd() );
+	    }
+
+            char shortcut = YShortcut::normalized(YShortcut::findShortcut(item->label()));
+
+            if ( shortcut == 0 )
+            {
+                conflicts.push_back(item);
+                yuiMilestone() << "No or invalid shortcut found " << item->label() << endl;
+            }
+            else if ( used[ (unsigned)shortcut ] )
+            {
+                conflicts.push_back(item);
+                yuiWarning() << "Conflicting shortcut found " << item->label() << endl;
+            }
+            else
+            {
+                used[ (unsigned) shortcut ] = true;
+            }
+	}
+        else
+        {
+            yuiWarning() << "non menu item used in call " << (*it)->label() << endl;
+        }
+    }
+
+    // cannot use YShortcut directly as an YItem is not a YWidget
+    for( YMenuItem *i: conflicts )
+    {
+        string clean = YShortcut::cleanShortcutString(i->label());
+        char new_c = 0;
+
+        size_t index = 0;
+        for (; index < clean.size(); ++index)
+        {
+            char ch = YShortcut::normalized( clean[index] );
+            // ch is set to 0 by normalized() if not valid
+            if ( ch != 0 && ! used[ (unsigned)ch ] )
+            {
+                new_c = ch;
+                used[(unsigned)ch] = true;
+                break;
+            }
+        }
+
+        if (new_c != 0)
+        {
+            clean.insert(index, 1, YShortcut::shortcutMarker());
+            yuiMilestone() << "New label used: " << clean << endl;
+        }
+
+        i->setLabel( clean );
+    }
+}
+
+
+void
+YMenuWidget::resolveShortcutConflicts()
+{
+    resolveShortcutConflicts( itemsBegin(), itemsEnd() );
+}
+
+
+YMenuItem *
+YMenuWidget::findItem( std::vector<std::string> & path ) const
+{
+    return findItem( path.begin(), path.end(),
+                     itemsBegin(), itemsEnd() );
+}
+
+
+YMenuItem *
+YMenuWidget::findItem( std::vector<std::string>::iterator path_begin,
+                       std::vector<std::string>::iterator path_end,
+                       YItemConstIterator                 begin,
+                       YItemConstIterator                 end ) const
+{
+    for ( YItemConstIterator it = begin; it != end; ++it )
+    {
+        YMenuItem * item = dynamic_cast<YMenuItem *>(*it);
+        // Test that dynamic_cast didn't fail
+
+        if ( !item )
+            return 0;
+
+        if ( item->label() == *path_begin )
+        {
+            if ( std::next(path_begin) == path_end )
+            {
+                // Only return items which can trigger an action.
+                // Intermediate items only open a submenu, so continue looking.
+                if( item->hasChildren() )
+                    continue;
+
+                return item;
+            }
+
+            // Look in child nodes and return if found one
+            YMenuItem * result = findItem( ++path_begin, path_end,
+                                           item->childrenBegin(), item->childrenEnd() );
+            if ( result )
+                return result;
+        }
+    }
+    return 0;
+}
+
+
+const YPropertySet &
+YMenuWidget::propertySet()
+{
+    static YPropertySet propSet;
+
+    if ( propSet.isEmpty() )
+    {
+	/*
+	 * @property itemList	Items		All menu items and submenus
+	 * @property string	IconPath	Base path for icons (on menu items)
+	 */
+	propSet.add( YProperty( YUIProperty_Items,		YOtherProperty	 ) );
+	propSet.add( YProperty( YUIProperty_IconPath,		YStringProperty	 ) );
+	propSet.add( YWidget::propertySet() );
+    }
+
+    return propSet;
+}
+
+
+bool
+YMenuWidget::setProperty( const string & propertyName, const YPropertyValue & val )
+{
+    propertySet().check( propertyName, val.type() ); // throws exceptions if not found or type mismatch
+
+    if      ( propertyName == YUIProperty_Items 	)	return false; // Needs special handling
+    else if ( propertyName == YUIProperty_IconPath 	)	setIconBasePath( val.stringVal() );
+    else
+    {
+	return YWidget::setProperty( propertyName, val );
+    }
+
+    return true; // success -- no special processing necessary
+}
+
+
+YPropertyValue
+YMenuWidget::getProperty( const string & propertyName )
+{
+    propertySet().check( propertyName ); // throws exceptions if not found
+
+    if      ( propertyName == YUIProperty_Label		)	return YPropertyValue( label() );
+    else if ( propertyName == YUIProperty_Items 	)	return YPropertyValue( YOtherProperty );
+    else if ( propertyName == YUIProperty_IconPath	)	return YPropertyValue( iconBasePath() );
+    else
+    {
+	return YWidget::getProperty( propertyName );
+    }
+}
+

--- a/src/YMenuWidget.h
+++ b/src/YMenuWidget.h
@@ -1,0 +1,228 @@
+/*
+  Copyright (c) [2020] SUSE LLC
+  This library is free software; you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as
+  published by the Free Software Foundation; either version 2.1 of the
+  License, or (at your option) version 3.0 of the License. This library
+  is distributed in the hope that it will be useful, but WITHOUT ANY
+  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+  FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+  License for more details. You should have received a copy of the GNU
+  Lesser General Public License along with this library; if not, write
+  to the Free Software Foundation, Inc., 51 Franklin Street, Fifth
+  Floor, Boston, MA 02110-1301 USA
+*/
+
+
+/*-/
+
+  File:		YMenuWidget.h
+
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
+
+/-*/
+
+#ifndef YMenuWidget_h
+#define YMenuWidget_h
+
+#include "YSelectionWidget.h"
+#include "YMenuItem.h"
+
+class YMenuWidgetPrivate;
+
+
+/**
+ * Abstract base class for widgets that handle menus, e.g. YMenuButton or
+ * YMenuBar.
+ **/
+class YMenuWidget: public YSelectionWidget
+{
+protected:
+    /**
+     * Constructor.
+     *
+     * 'label' is only passed through to the inherited class. For a menu
+     * button, this would be the label on the button; a menu bar does not have
+     * a label.
+     **/
+    YMenuWidget( YWidget * parent, const std::string & label = "" );
+
+public:
+
+    /**
+     * Destructor.
+     **/
+    virtual ~YMenuWidget();
+
+    /**
+     * Returns a descriptive name of this widget class for logging,
+     * debugging etc.
+     **/
+    virtual const char * widgetClass() const { return "YMenuWidget"; }
+
+    /**
+     * Rebuild the displayed menu tree from the internally stored YMenuItems.
+     *
+     * The application should call this (once) after all items have been added
+     * with addItem(). YMenuButton::addItems() calls this automatically.
+     *
+     * Derived classes are required to implement this.
+     **/
+    virtual void rebuildMenuTree() = 0;
+
+    /**
+     * Add multiple items. For some UIs, this can be more efficient than
+     * calling addItem() multiple times. This function also automatically calls
+     * resolveShortcutConflicts() and rebuildMenuTree() at the end.
+     *
+     * Derived classes can overwrite this function, but they should call this
+     * base class function at the end of the new implementation.
+     *
+     * Reimplemented from YSelectionWidget.
+     **/
+    virtual void addItems( const YItemCollection & itemCollection );
+
+    /**
+     * Add one item. This widget assumes ownership of the item object and will
+     * delete it in its destructor.
+     *
+     * This reimplementation will an index to the item that is unique for all
+     * items in this MenuButton. That index can be used later with
+     * findMenuItem() to find the item by that index.
+     *
+     * @note please do not forget to call after adding all elements
+     * #resolveShortcutConflicts and #rebuildMenuTree in this order. It is
+     * important to call it after all submenus are added, otherwise it won't
+     * have proper shortcuts and won't be rendered.
+     * @see examples/MenuButton.cc.
+     *
+     * Reimplemented from YSelectionWidget.
+     **/
+    virtual void addItem( YItem * item_disown );
+
+    /**
+     * Delete all items.
+     *
+     * Reimplemented from YSelectionWidget.
+     **/
+    virtual void deleteAllItems();
+
+    /**
+     * Resolve keyboard shortcut conflicts: Change shortcuts of menu items if
+     * there are duplicates in the respective menu level.
+     *
+     * This has to be called after all items are added, but before
+     * rebuildMenuTree() (see above). YMenuWidget::addItems() calls this
+     * automatically.
+     **/
+    void resolveShortcutConflicts();
+
+    /**
+     * Set a property.
+     * Reimplemented from YWidget.
+     *
+     * This function may throw YUIPropertyExceptions.
+     *
+     * This function returns 'true' if the value was successfully set and
+     * 'false' if that value requires special handling (not in error cases:
+     * those are covered by exceptions).
+     **/
+    virtual bool setProperty( const std::string    & propertyName,
+			      const YPropertyValue & val );
+
+    /**
+     * Get a property.
+     * Reimplemented from YWidget.
+     *
+     * This method may throw YUIPropertyExceptions.
+     **/
+    virtual YPropertyValue getProperty( const std::string & propertyName );
+
+    /**
+     * Return this class's property set.
+     * This also initializes the property upon the first call.
+     *
+     * Reimplemented from YWidget.
+     **/
+    virtual const YPropertySet & propertySet();
+
+    /**
+     * Support for the Rest API for UI testing:
+     *
+     * Return the item in the tree which matches a path of labels. This
+     * returns 0 if there is no such item or if it is not a leaf menu item.
+     *
+     * 'path' specifies the user-visible labels (i.e. the translated texts) of
+     * each menu level ( ["File", "Export", "As XML"] ).
+     **/
+    YMenuItem * findItem( std::vector<std::string> & path ) const;
+
+    /**
+     * Support for the Rest API for UI testing:
+     *
+     * Activate the item selected in the tree.
+     * This can be used in tests to simulate user input.
+     *
+     * Derived classes are required to implement this.
+     **/
+    virtual void activateItem( YMenuItem * item ) = 0;
+
+    /**
+     * Recursively find the first menu item with the specified index.
+     * Returns 0 if there is no such item.
+     **/
+    YMenuItem * findMenuItem( int index );
+
+
+protected:
+
+    /**
+     * Resolve keyboard shortcut conflicts between iterators 'begin' and 'end'.
+     **/
+    void resolveShortcutConflicts( YItemConstIterator begin,
+                                   YItemConstIterator end );
+
+    /**
+     * Recursively find the first menu item with the specified index
+     * from iterator 'begin' to iterator 'end'.
+     *
+     * Returns 0 if there is no such item.
+     **/
+    YMenuItem * findMenuItem( int                index,
+                              YItemConstIterator begin,
+                              YItemConstIterator end );
+
+    /**
+     * Recursively looks for the first item in the tree of the menu items
+     * using depth first search.
+     * Return nullptr if item which matches full path is not found.
+     * Path is a vector of strings, where next element is a child item, so
+     * in case one needs to select File->Export->As PDF, for instance,
+     * Vector will look like [ "File", "Export", "As PDF" ].
+     */
+    YMenuItem * findItem( std::vector<std::string>::iterator path_begin,
+                          std::vector<std::string>::iterator path_end,
+                          YItemConstIterator                 begin,
+                          YItemConstIterator                 end ) const;
+
+    /**
+     * Alias for findMenuItem(). Reimplemented to ensure consistent behaviour
+     * with YSelectionWidget::itemAt().
+     **/
+    YMenuItem * itemAt( int index )
+	{ return findMenuItem( index ); }
+
+    /**
+     * Assign a unique index to all items from iterator 'begin' to iterator
+     * 'end'.
+     **/
+    void assignUniqueIndex( YItemIterator begin, YItemIterator end );
+
+
+private:
+
+    ImplPtr<YMenuWidgetPrivate> priv;
+};
+
+
+#endif  // YMenuWidget_h

--- a/src/YMenuWidget.h
+++ b/src/YMenuWidget.h
@@ -115,33 +115,14 @@ public:
     void resolveShortcutConflicts();
 
     /**
-     * Set a property.
-     * Reimplemented from YWidget.
+     * Enable or disable an item. This default implementation only updates the
+     * item's 'enabled' field.
      *
-     * This function may throw YUIPropertyExceptions.
-     *
-     * This function returns 'true' if the value was successfully set and
-     * 'false' if that value requires special handling (not in error cases:
-     * those are covered by exceptions).
+     * Derived classes should overwrite this method and either update the
+     * item's 'enabled' field in their implementation or call this default
+     * implementation.
      **/
-    virtual bool setProperty( const std::string    & propertyName,
-			      const YPropertyValue & val );
-
-    /**
-     * Get a property.
-     * Reimplemented from YWidget.
-     *
-     * This method may throw YUIPropertyExceptions.
-     **/
-    virtual YPropertyValue getProperty( const std::string & propertyName );
-
-    /**
-     * Return this class's property set.
-     * This also initializes the property upon the first call.
-     *
-     * Reimplemented from YWidget.
-     **/
-    virtual const YPropertySet & propertySet();
+    virtual void setItemEnabled( YMenuItem * item, bool enabled );
 
     /**
      * Support for the Rest API for UI testing:
@@ -170,6 +151,14 @@ public:
      **/
     YMenuItem * findMenuItem( int index );
 
+
+    // No propertySet(), setProperty(), getProperty() on this level:
+    //
+    // This is left to derived widgets (very much like for YSelectionWidget)
+    // so they can be tailored to what they really can provide.
+    //
+    // There is infrastructure for properties like "EnabledItems" here and in
+    // the UI bindings, though, to easily support those properties.
 
 protected:
 

--- a/src/YMenuWidget.h
+++ b/src/YMenuWidget.h
@@ -90,11 +90,8 @@ public:
      * items in this MenuButton. That index can be used later with
      * findMenuItem() to find the item by that index.
      *
-     * @note please do not forget to call after adding all elements
-     * #resolveShortcutConflicts and #rebuildMenuTree in this order. It is
-     * important to call it after all submenus are added, otherwise it won't
-     * have proper shortcuts and won't be rendered.
-     * @see examples/MenuButton.cc.
+     * @note Do not forget to call #resolveShortcutConflicts and
+     * #rebuildMenuTree (in this order!) after adding all elements.
      *
      * Reimplemented from YSelectionWidget.
      **/

--- a/src/YMenuWidget.h
+++ b/src/YMenuWidget.h
@@ -86,8 +86,8 @@ public:
      * Add one item. This widget assumes ownership of the item object and will
      * delete it in its destructor.
      *
-     * This reimplementation will an index to the item that is unique for all
-     * items in this MenuButton. That index can be used later with
+     * This reimplementation will assign an index to the item that is unique
+     * for all items in this MenuButton. That index can be used later with
      * findMenuItem() to find the item by that index.
      *
      * @note Do not forget to call #resolveShortcutConflicts and

--- a/src/YMultiLineEdit.cc
+++ b/src/YMultiLineEdit.cc
@@ -18,7 +18,7 @@
 
   File:		YMultiLineEdit.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YMultiLineEdit.h
+++ b/src/YMultiLineEdit.h
@@ -18,7 +18,7 @@
 
   File:		YMultiLineEdit.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YMultiProgressMeter.cc
+++ b/src/YMultiProgressMeter.cc
@@ -18,7 +18,7 @@
 
   File:		YMultiProgressMeter.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YMultiProgressMeter.h
+++ b/src/YMultiProgressMeter.h
@@ -18,7 +18,7 @@
 
   File:		YMultiProgressMeter.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YMultiSelectionBox.cc
+++ b/src/YMultiSelectionBox.cc
@@ -18,7 +18,7 @@
 
   File:		YMultiSelectionBox.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YMultiSelectionBox.h
+++ b/src/YMultiSelectionBox.h
@@ -18,7 +18,7 @@
 
   File:		YSelectionBox.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YOptionalWidgetFactory.cc
+++ b/src/YOptionalWidgetFactory.cc
@@ -18,7 +18,7 @@
 
   File:		YOptionalWidgetFactory.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YOptionalWidgetFactory.h
+++ b/src/YOptionalWidgetFactory.h
@@ -18,7 +18,7 @@
 
   File:		YOptionalWidgetFactory.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YPackageSelector.cc
+++ b/src/YPackageSelector.cc
@@ -18,7 +18,7 @@
 
   File:		YPackageSelector.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YPackageSelector.h
+++ b/src/YPackageSelector.h
@@ -18,7 +18,7 @@
 
   File:		YPackageSelector.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YPackageSelectorPlugin.h
+++ b/src/YPackageSelectorPlugin.h
@@ -18,7 +18,7 @@
 
   File:		YPackageSelectorPlugin.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YPartitionSplitter.cc
+++ b/src/YPartitionSplitter.cc
@@ -18,7 +18,7 @@
 
   File:		YPartitionSplitter.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YPartitionSplitter.h
+++ b/src/YPartitionSplitter.h
@@ -18,7 +18,7 @@
 
   File:		YPartitionSplitter.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YProgressBar.cc
+++ b/src/YProgressBar.cc
@@ -18,7 +18,7 @@
 
   File:		YProgressBar.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YProgressBar.h
+++ b/src/YProgressBar.h
@@ -18,7 +18,7 @@
 
   File:		YProgressBar.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YProperty.cc
+++ b/src/YProperty.cc
@@ -18,7 +18,7 @@
 
   File:		YProperty.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YProperty.h
+++ b/src/YProperty.h
@@ -18,7 +18,7 @@
 
   File:		YProperty.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YPushButton.cc
+++ b/src/YPushButton.cc
@@ -18,7 +18,7 @@
 
   File:		YPushButton.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YPushButton.h
+++ b/src/YPushButton.h
@@ -18,7 +18,7 @@
 
   File:		YPushButton.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YRadioButton.cc
+++ b/src/YRadioButton.cc
@@ -18,7 +18,7 @@
 
   File:		YRadioButton.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YRadioButton.h
+++ b/src/YRadioButton.h
@@ -18,7 +18,7 @@
 
   File:		YRadioButton.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YRadioButtonGroup.cc
+++ b/src/YRadioButtonGroup.cc
@@ -18,7 +18,7 @@
 
   File:		YRadioButtonGroup.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YRadioButtonGroup.h
+++ b/src/YRadioButtonGroup.h
@@ -18,7 +18,7 @@
 
   File:		YRadioButtonGroup.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YReplacePoint.cc
+++ b/src/YReplacePoint.cc
@@ -18,7 +18,7 @@
 
   File:		YReplacePoint.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YReplacePoint.h
+++ b/src/YReplacePoint.h
@@ -18,7 +18,7 @@
 
   File:		YReplacePoint.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YRichText.cc
+++ b/src/YRichText.cc
@@ -19,7 +19,7 @@
 
   File:		YRichText.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YRichText.h
+++ b/src/YRichText.h
@@ -19,7 +19,7 @@
 
   File:		YRichText.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YRpmGroupsTree.cc
+++ b/src/YRpmGroupsTree.cc
@@ -18,7 +18,7 @@
 
   File:	      YRpmGroupsTree.cc
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YRpmGroupsTree.h
+++ b/src/YRpmGroupsTree.h
@@ -18,7 +18,7 @@
 
   File:	      YRpmGroupsTree.h
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YSelectionBox.cc
+++ b/src/YSelectionBox.cc
@@ -18,7 +18,7 @@
 
   File:		YSelectionBox.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YSelectionBox.h
+++ b/src/YSelectionBox.h
@@ -18,7 +18,7 @@
 
   File:		YSelectionBox.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YSelectionWidget.h
+++ b/src/YSelectionWidget.h
@@ -18,7 +18,7 @@
 
   File:		YSelectionWidget.h
 
-  Author:     	Stefan Hundhammer <sh@suse.de>
+  Author:     	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YShortcut.cc
+++ b/src/YShortcut.cc
@@ -18,7 +18,7 @@
 
   File:		YShortcut.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YShortcut.h
+++ b/src/YShortcut.h
@@ -18,7 +18,7 @@
 
   File:		YShortcut.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YShortcutManager.cc
+++ b/src/YShortcutManager.cc
@@ -18,7 +18,7 @@
 
   File:		YShortcutManager.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YShortcutManager.h
+++ b/src/YShortcutManager.h
@@ -18,7 +18,7 @@
 
   File:		YShortcutManager.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YSimpleEventHandler.cc
+++ b/src/YSimpleEventHandler.cc
@@ -18,7 +18,7 @@
 
   File:		YEvent.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YSimpleEventHandler.h
+++ b/src/YSimpleEventHandler.h
@@ -18,7 +18,7 @@
 
   File:		YSimpleEventHandler.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YSimpleInputField.cc
+++ b/src/YSimpleInputField.cc
@@ -18,7 +18,7 @@
 
   File:		YSimpleInputField.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YSimpleInputField.h
+++ b/src/YSimpleInputField.h
@@ -18,7 +18,7 @@
 
   File:		YSimpleInputField.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YSingleChildContainerWidget.cc
+++ b/src/YSingleChildContainerWidget.cc
@@ -18,7 +18,7 @@
 
   File:		YSingleChildContainerWidget.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YSingleChildContainerWidget.h
+++ b/src/YSingleChildContainerWidget.h
@@ -18,7 +18,7 @@
 
   File:		YSingleChildContainerWidget.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YSlider.cc
+++ b/src/YSlider.cc
@@ -18,7 +18,7 @@
 
   File:		YSlider.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YSlider.h
+++ b/src/YSlider.h
@@ -18,7 +18,7 @@
 
   File:		YSlider.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YSpacing.cc
+++ b/src/YSpacing.cc
@@ -18,7 +18,7 @@
 
   File:		YEmpty.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YSpacing.h
+++ b/src/YSpacing.h
@@ -18,7 +18,7 @@
 
   File:		YSpacing.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YSquash.cc
+++ b/src/YSquash.cc
@@ -18,7 +18,7 @@
 
    File:	YSquash.cc
 
-   Author:	Stefan Hundhammer <sh@suse.de>
+   Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YSquash.h
+++ b/src/YSquash.h
@@ -18,7 +18,7 @@
 
   File:		YSquash.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YStringTree.cc
+++ b/src/YStringTree.cc
@@ -18,7 +18,7 @@
 
   File:	      YStringTree.cc
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YStringTree.h
+++ b/src/YStringTree.h
@@ -18,7 +18,7 @@
 
   File:	      YStringTree.h
 
-  Author:     Stefan Hundhammer <sh@suse.de>
+  Author:     Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YTable.cc
+++ b/src/YTable.cc
@@ -18,7 +18,7 @@
 
   File:		YTable.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YTable.h
+++ b/src/YTable.h
@@ -18,7 +18,7 @@
 
   File:		YTable.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YTableHeader.cc
+++ b/src/YTableHeader.cc
@@ -18,7 +18,7 @@
 
   File:		YTableHeader.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YTableHeader.h
+++ b/src/YTableHeader.h
@@ -18,7 +18,7 @@
 
   File:		YTableHeader.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YTableItem.cc
+++ b/src/YTableItem.cc
@@ -18,7 +18,7 @@
 
   File:		YTableItem.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YTableItem.h
+++ b/src/YTableItem.h
@@ -18,7 +18,7 @@
 
   File:         YTableItem.h
 
-  Author:       Stefan Hundhammer <sh@suse.de>
+  Author:       Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YTimeField.cc
+++ b/src/YTimeField.cc
@@ -18,7 +18,7 @@
 
   File:		YTimeField.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YTimeField.h
+++ b/src/YTimeField.h
@@ -18,7 +18,7 @@
 
   File:		YTimeField.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YTransText.h
+++ b/src/YTransText.h
@@ -18,7 +18,7 @@
 
   File:		YTransText.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YTree.cc
+++ b/src/YTree.cc
@@ -18,7 +18,7 @@
 
   File:		YTree.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YTree.h
+++ b/src/YTree.h
@@ -18,7 +18,7 @@
 
   File:		YTree.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YTreeItem.cc
+++ b/src/YTreeItem.cc
@@ -18,7 +18,7 @@
 
   File:		YTreeItem.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YTreeItem.h
+++ b/src/YTreeItem.h
@@ -18,7 +18,7 @@
 
   File:		YTreeItem.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YTypes.h
+++ b/src/YTypes.h
@@ -17,7 +17,7 @@
 /**
  @file		YTypes.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
   Header file for frequently used simple types to reduce interdependencies
   between important headers (e.g., YWidget.h, YUI.h).

--- a/src/YUI.cc
+++ b/src/YUI.cc
@@ -18,7 +18,7 @@
 
   File:		YUI.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YUI.h
+++ b/src/YUI.h
@@ -18,7 +18,7 @@
 
   File:		YUI.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YUIException.cc
+++ b/src/YUIException.cc
@@ -21,7 +21,7 @@
 		Stolen from zypp/libzypp/base/Exception.cc
 
   Author:	Michael Andres    <ma@suse.de>
-  Maintainer:	Stefan Hundhammer <sh@suse.de>
+  Maintainer:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YUIException.h
+++ b/src/YUIException.h
@@ -21,7 +21,7 @@
 		Stolen from zypp/libzypp/base/Exception.h
 
   Author:     	Michael Andres    <ma@suse.de>
-  Maintainer:	Stefan Hundhammer <sh@suse.de>
+  Maintainer:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YUILoader.cc
+++ b/src/YUILoader.cc
@@ -18,7 +18,7 @@
 
   File:		YUILoader.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YUILoader.h
+++ b/src/YUILoader.h
@@ -18,7 +18,7 @@
 
   File:		YUILoader.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YUILog.cc
+++ b/src/YUILog.cc
@@ -18,7 +18,7 @@
 
   File:		YUILog.cc
 
-  Author:     	Stefan Hundhammer <sh@suse.de>
+  Author:     	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YUILog.h
+++ b/src/YUILog.h
@@ -18,7 +18,7 @@
 
   File:		YUILog.h
 
-  Author:     	Stefan Hundhammer <sh@suse.de>
+  Author:     	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YUIPlugin.cc
+++ b/src/YUIPlugin.cc
@@ -18,7 +18,7 @@
 
   File:		YUIPlugin.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YUIPlugin.h
+++ b/src/YUIPlugin.h
@@ -18,7 +18,7 @@
 
   File:		YUIPlugin.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YUISymbols.h
+++ b/src/YUISymbols.h
@@ -108,6 +108,7 @@
 #define YUIWidget_Left				"Left"
 #define YUIWidget_LogView			"LogView"
 #define YUIWidget_MarginBox			"MarginBox"
+#define YUIWidget_MenuBar                       "MenuBar"
 #define YUIWidget_MenuButton			"MenuButton"
 #define YUIWidget_MinHeight			"MinHeight"
 #define YUIWidget_MinSize			"MinSize"

--- a/src/YUISymbols.h
+++ b/src/YUISymbols.h
@@ -19,7 +19,7 @@
 
   File:		YUISymbols.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YUISymbols.h
+++ b/src/YUISymbols.h
@@ -1,6 +1,6 @@
 /*
   Copyright (C) 2000-2012 Novell, Inc
-  Copyright (C) 2019 SUSE LLC
+  Copyright (C) 2019-2020 SUSE LLC
   This library is free software; you can redistribute it and/or modify
   it under the terms of the GNU Lesser General Public License as
   published by the Free Software Foundation; either version 2.1 of the
@@ -174,6 +174,7 @@
 #define YUIProperty_DebugLabel			"DebugLabel"
 #define YUIProperty_EasterEgg			"EasterEgg"
 #define YUIProperty_Enabled			"Enabled"
+#define YUIProperty_EnabledItems		"EnabledItems"
 #define YUIProperty_ExpectedSize		"ExpectedSize"
 #define YUIProperty_Filename			"Filename"
 #define YUIProperty_Layout			"Layout"

--- a/src/YWidget.cc
+++ b/src/YWidget.cc
@@ -18,7 +18,7 @@
 
   File:		YWidget.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YWidget.h
+++ b/src/YWidget.h
@@ -18,7 +18,7 @@
 
   File:		YWidget.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YWidgetFactory.cc
+++ b/src/YWidgetFactory.cc
@@ -18,7 +18,7 @@
 
   File:		YWidgetFactory.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YWidgetFactory.cc
+++ b/src/YWidgetFactory.cc
@@ -316,3 +316,19 @@ YWidgetFactory::createCustomStatusItemSelector( YWidget * parent,
     return createItemSelector( parent,
                                false ); // enforceSingleSelection
 }
+
+
+YMenuBar *
+YWidgetFactory::createMenuBar( YWidget * parent )
+{
+    (void) parent;
+
+    // Default implementation returning 0 to give community-maintained UIs
+    // (libyui-gtk) a chance to catch up with development. Remove this and make
+    // it pure virtual when this is implemented there as well.
+
+    yuiError() << "YMenuBar not implemented in this UI" << endl;
+
+    return 0;
+}
+

--- a/src/YWidgetFactory.h
+++ b/src/YWidgetFactory.h
@@ -48,6 +48,7 @@ class YItemSelector;
 class YLabel;
 class YLayoutBox;
 class YLogView;
+class YMenuBar;
 class YMenuButton;
 class YMultiLineEdit;
 class YMultiSelectionBox;
@@ -189,6 +190,9 @@ public:
     YItemSelector *		createSingleItemSelector       ( YWidget * parent );
     YItemSelector *		createMultiItemSelector	       ( YWidget * parent );
     virtual YItemSelector *	createCustomStatusItemSelector ( YWidget * parent, const YItemCustomStatusVector & customStates );
+
+    virtual YMenuBar *          createMenuBar                  ( YWidget * parent );
+
 
 protected:
 

--- a/src/YWidgetFactory.h
+++ b/src/YWidgetFactory.h
@@ -18,7 +18,7 @@
 
   File:		YWidgetFactory.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YWidgetID.cc
+++ b/src/YWidgetID.cc
@@ -18,7 +18,7 @@
 
   File:		YWidgetID.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YWidgetID.h
+++ b/src/YWidgetID.h
@@ -18,7 +18,7 @@
 
   File:		YWidgetID.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YWizard.cc
+++ b/src/YWizard.cc
@@ -18,7 +18,7 @@
 
   File:		YWizard.cc
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 /-*/
 

--- a/src/YWizard.h
+++ b/src/YWizard.h
@@ -18,7 +18,7 @@
 
   @file		YWizard.h
 
-  Author:	Stefan Hundhammer <sh@suse.de>
+  Author:	Stefan Hundhammer <shundhammer@suse.de>
 
 **/
 


### PR DESCRIPTION
## Trello

https://trello.com/c/4GtDpmMo/

## Bugzilla

https://bugzilla.opensuse.org/show_bug.cgi?id=1175115

## Overview

This adds a MenuBar widget to the YaST UI.

Features:

- A menu bar that spans the width of the parent widget
- Pulldown menus
- Menu items that can trigger an action
- Separators
- Submenus
- Enabling / disabling individual items or complete menus / submenus
- Optional icons for items and submenus
- Automatic keyboard shortcut resolving on each menu level

## Caveat

We normally use wizards everywhere which is a completely different approach to user interfaces. In certain cases, though, a traditional menu bar with pulldown menus is still useful.

We have it in the PackageSelector (which is a high-level standalone widget that implements it in pure Qt or pure NCurses), but it would also be desirable to have it in the partitioner which has a _lot_ of actions that are right now all organized in buttons or MenuButtons.

## Screenshot

![MenuBar1-rb](https://user-images.githubusercontent.com/11538225/87427258-cd8ae700-c5e0-11ea-98ca-990267b3684f.png)


## Details

### Creating Menus

Add nested items, very much like for the tree widget.

### Separators

Use an item with an empty label or with a label that starts with `---` (three "minus" signs).

### Enabling / Disabling Items

Create a hash with the IDs of the items that are to be enabled or disabled and a boolean for the new enabled/disabled status and call `UI.ChangeWidget(:menu_bar_id, :EnabledItems, my_hash)` with it:

```Ruby
      UI.ChangeWidget(:menu_bar, :EnabledItems,
        {
          :save  => true,
          :cut   => false,
          :paste => false
        }
      )
```

All other items in the menus will remain untouched, i.e. they will keep their current enabled / disabled status.

## Comprehensive Example

See yast-ycp-ui-bindings/examples/MenuBar1.rb:

(Click the arrow to open)
<details>

```Ruby

# encoding: utf-8

module Yast
  class MenuBar1Client < Client
    Yast.import "UI"
    def main
      UI.OpenDialog(dialog_widgets)
      update_actions
      handle_events
      UI.CloseDialog
      nil
    end

    def dialog_widgets
      MinSize( 50, 20,
        VBox(
          term(:MenuBar, Id(:menu_bar), main_menus ),
          HVCenter(
            HVSquash(
              VBox(
                Left(Label( "Last Event:" )),
                VSpacing( 0.2 ),
                MinWidth( 20,
                  Label(Id(:last_event), Opt(:outputField), "<none>")
                ),
                VSpacing( 2 ),
                CheckBox(Id(:read_only), Opt(:notify), "Read &Only", true )
              )
            )
          )
        )
      )
    end

    def main_menus
      [
        term(:menu, "&File", file_menu),
        term(:menu, "&Edit", edit_menu),
        term(:menu, "&View", view_menu),
        term(:menu, "&Options", options_menu)
      ].freeze
    end

    def file_menu
      [
        Item(Id(:open), "&Open..."),
        Item(Id(:save), "&Save"),
        Item(Id(:save_as), "Save &As..."),
        Item("---"),
        Item(Id(:quit), "&Quit"),
      ].freeze
    end

    def edit_menu
      [
        Item(Id(:cut), "C&ut"),
        Item(Id(:copy), "&Copy"),
        Item(Id(:paste), "&Paste"),
      ].freeze
    end

    def view_menu
      [
        Item(Id(:view_normal), "&Normal"),
        Item(Id(:view_compact), "&Compact"),
        Item(Id(:view_detailed), "&Detailed"),
        Item("---"),
        term(:menu, "&Zoom", zoom_menu),
      ].freeze
    end

    def zoom_menu
      [
        Item(Id(:zoom_in), "Zoom &In" ),
        Item(Id(:zoom_out), "Zoom &Out" ),
        Item(Id(:zoom_default), "Zoom &Default" ),
      ].freeze
    end

    def options_menu
      [
        Item(Id(:settings), "&Settings..."),
      ].freeze
    end

    def handle_events
      while true
        id = UI.UserInput

        case id
        when :quit, :cancel # :cancel is WM_CLOSE
          break # leave event loop
        when :read_only
          update_actions
        end

        show_event(id)
      end
      id
    end

    def show_event(id)
      UI.ChangeWidget(:last_event, :Value, id.to_s)
    end

    # Enable or disable menu items depending on the current content of the
    # "Read Only" check box.
    def update_actions
      read_only = UI.QueryWidget(:read_only, :Value)

      # Enable or disable individual menu entries (actions as well as submenus):
      #
      # Specify a hash of item IDs with a boolean indicating if it should be
      # enabled (true) or disabled (false). Menu items that are not in this hash will
      # not be touched, i.e. they retain their current enabled / disabled status.

      UI.ChangeWidget(:menu_bar, :EnabledItems,
        {
          :save  => !read_only,
          :cut   => !read_only,
          :paste => !read_only
        }
      )
    end
  end
end

Yast::MenuBar1Client.new.main
```
</details>



## Related PRs

- Qt UI: https://github.com/libyui/libyui-qt/pull/130
- NCurses UI: https://github.com/libyui/libyui-ncurses/pull/97
- UI Interpreter: https://github.com/yast/yast-ycp-ui-bindings/pull/53

### libyui SO version bump PRs:

- https://github.com/libyui/libyui-rest-api/pull/8
- https://github.com/libyui/libyui-qt-pkg/pull/92
- https://github.com/libyui/libyui-qt-graph/pull/40
- https://github.com/libyui/libyui-qt-rest-api/pull/6
- https://github.com/libyui/libyui-ncurses-pkg/pull/43
- https://github.com/libyui/libyui-ncurses-rest-api/pull/5
