### PR TITLE
Manage multiple shortcuts

### DIFF
--- a/examples/MenuBar1.cc
+++ b/examples/MenuBar1.cc
@@ -34,6 +34,7 @@
 #include "YWidgetFactory.h"
 #include "YShortcut.h"
 #include "YEvent.h"
+#include "YPushButton.h"
 
 
 using std::string;
@@ -41,10 +42,11 @@ using std::string;
 
 // Widgets
 
-YDialog	  * dialog		= 0;
-YMenuBar  * menuBar		= 0;
-YLabel	  * lastEventLabel	= 0;
-YCheckBox * readOnlyCheckBox	= 0;
+YDialog	    * dialog		= 0;
+YMenuBar    * menuBar		= 0;
+YLabel	    * lastEventLabel	= 0;
+YCheckBox   * readOnlyCheckBox	= 0;
+YPushButton * closeButton	= 0;
 
 
 // Menus and Menu Items
@@ -53,6 +55,7 @@ YMenuItem * fileMenu		= 0;
 YMenuItem * editMenu		= 0;
 YMenuItem * viewMenu		= 0;
 YMenuItem * optionsMenu		= 0;
+YMenuItem * contentsMenu	= 0;
 
 
 // "File" menu
@@ -84,9 +87,15 @@ YMenuItem * actionZoomIn	= 0;
 YMenuItem * actionZoomOut	= 0;
 YMenuItem * actionZoomDefault	= 0;
 
+
 // "Options" menu
 
 YMenuItem * actionSettings	= 0;
+
+
+// "Contents" menu
+
+YMenuItem * actionClear		= 0;
 
 
 // Function Prototypes
@@ -142,6 +151,8 @@ void createWidgets()
     fac->createVSpacing( vbox2, 2 );
     readOnlyCheckBox = fac->createCheckBox( vbox2, "Read &Only", true );
     readOnlyCheckBox->setNotify( true );
+    fac->createVSpacing( vbox2, 0.2 );
+    closeButton = fac->createPushButton( vbox2, "&Close" );
 }
 
 
@@ -150,10 +161,11 @@ void addMenus( YMenuBar * menuBar )
     // The difference between a menu and a plain menu item is just that the
     // menu has child items whild the plain item does not.
 
-    fileMenu	= menuBar->addMenu( "&File" );
-    editMenu	= menuBar->addMenu( "&Edit" );
-    viewMenu	= menuBar->addMenu( "&View" );
-    optionsMenu = menuBar->addMenu( "&Options" );
+    fileMenu	 = menuBar->addMenu( "&File" );
+    editMenu	 = menuBar->addMenu( "&Edit" );
+    viewMenu	 = menuBar->addMenu( "&View" );
+    optionsMenu  = menuBar->addMenu( "&Options" );
+    contentsMenu = menuBar->addMenu( "&Contents" );
 
     actionOpen		= fileMenu->addItem( "&Open..."	   );
     actionSave		= fileMenu->addItem( "&Save"	   );
@@ -176,6 +188,8 @@ void addMenus( YMenuBar * menuBar )
     actionZoomDefault	= zoomMenu->addItem( "Zoom &Default" );
 
     actionSettings	= optionsMenu->addItem( "&Settings..." );
+
+    actionClear		= contentsMenu->addItem( "&Clear" );
 
     menuBar->resolveShortcutConflicts();
     menuBar->rebuildMenuTree();
@@ -215,6 +229,9 @@ void handleEvents()
 
 	    if ( event->widget() == readOnlyCheckBox )
 		updateActions();
+
+	    if ( event->widget() == closeButton )
+		break;
 	}
     }
 }

--- a/src/YDumbTab.h
+++ b/src/YDumbTab.h
@@ -68,14 +68,6 @@ public:
     virtual void addItem( YItem * item );
 
     /**
-     * Notification that any shortcut of any item was changed by the shortcut
-     * conflict manager.
-     *
-     * Derived classes should reimplement this.
-     **/
-    virtual void shortcutChanged() {}
-
-    /**
      * Set a property.
      * Reimplemented from YWidget.
      *
@@ -107,27 +99,6 @@ public:
      * Reimplemented from YWidget.
      **/
     virtual const YPropertySet & propertySet();
-
-    /**
-     * Get the string of this widget that holds the keyboard shortcut.
-     * Notice that since YDumbTab has one shortcut for each tab page (for each
-     * item), this is not meaningful for this widget class.
-     *
-     * Check YItemShortcut in YShortcut.{cc,h} for more details.
-     *
-     * Reimplemented from YSelectionWidget.
-     **/
-    virtual std::string shortcutString() const { return ""; }
-
-    /**
-     * Set the string of this widget that holds the keyboard shortcut.
-     * Since YDumbTab doesn't have a shortcut for the widget itself (only for
-     * the tab pages, i.e. the items), this will simply trigger a
-     * shortcutChanged() notification.
-     *
-     * Reimplemented from YSelectionWidget.
-     **/
-    virtual void setShortcutString( const std::string & str ) { shortcutChanged(); }
 
     /**
      * Returns 'true' if this widget is stretchable in the specified dimension.

--- a/src/YSelectionWidget.cc
+++ b/src/YSelectionWidget.cc
@@ -140,6 +140,13 @@ void YSelectionWidget::setEnforceSingleSelection( bool enforceSingleSelection )
 }
 
 
+void YSelectionWidget::setShortcutString( const std::string & str )
+{
+    setLabel( str );
+    shortcutChanged();
+}
+
+
 void YSelectionWidget::setIconBasePath( const string & basePath )
 {
     priv->iconBasePath = basePath;

--- a/src/YSelectionWidget.h
+++ b/src/YSelectionWidget.h
@@ -271,21 +271,6 @@ public:
     YItem * findItem( const std::string & itemLabel ) const;
 
     /**
-     * Get the string of this widget that holds the keyboard shortcut.
-     *
-     * Reimplemented from YWidget.
-     **/
-    virtual std::string shortcutString() const { return label(); }
-
-    /**
-     * Set the string of this widget that holds the keyboard shortcut.
-     *
-     * Reimplemented from YWidget.
-     **/
-    virtual void setShortcutString( const std::string & str )
-	{ setLabel( str ); }
-
-    /**
      * Dump all items and their selection state to the log.
      **/
     void dumpItems() const;
@@ -294,6 +279,37 @@ public:
      * Return 'true' if this base class should enforce single selection.
      **/
     bool enforceSingleSelection() const;
+
+    /**
+     * Notification that any shortcut of any item was changed by the shortcut conflict manager.
+     *
+     * Derived classes should reimplement this.
+     **/
+    virtual void shortcutChanged() {}
+
+    /**
+     * Get the string of this widget that holds the keyboard shortcut.
+     *
+     * Notice that some sub-classes (e.g., YDumbTab, YItemSelection, YMenuBar) has one shortcut for each
+     * item. This value is not meaningful for such widget classes.
+     *
+     * Check YItemShortcut in YShortcut.{cc,h} for more details.
+     *
+     * Reimplemented from YWidget.
+     **/
+    virtual std::string shortcutString() const { return label(); }
+
+    /**
+     * Set the string of this widget that holds the keyboard shortcut.
+     *
+     * Also trigger a shortcutChanged() notification. This is useful for derived sub-classes to
+     * refresh the widget when any shortcut of any item was changed by the shortcut conflict manager.
+     *
+     * Check YItemShortcut in YShortcut.{cc,h} for more details.
+     *
+     * Reimplemented from YWidget.
+     **/
+    virtual void setShortcutString( const std::string & str );
 
 protected:
 

--- a/src/YShortcut.h
+++ b/src/YShortcut.h
@@ -42,6 +42,7 @@ class YShortcut
 public:
     /**
      * Constructor
+     * @param shortcut_widget (not owned, not nullptr)
      **/
     YShortcut( YWidget *shortcut_widget );
 
@@ -91,23 +92,26 @@ public:
     /**
      * Returns the shortcut string ( from the widget's shortcut property )
      * without any "&" markers.
+     *
+     * But an escaped "&&" is preserved.
      **/
     std::string cleanShortcutString();
 
     /**
      * Static version of the above for general use:
      * Returns the specified string without any "&" markers.
+     * But an escaped "&&" is preserved.
      **/
     static std::string cleanShortcutString( std::string shortcutString );
 
     /**
      * The preferred shortcut character, i.e. the character that had been
-     * preceded by "&" before checking / resolving conflicts began.
+     * preceded by "&" before checking / resolving conflicts began. 0 if none.
      **/
     char preferred();
 
     /**
-     * The actual shortcut character.
+     * The actual shortcut character. 0 if none.
      *
      * This may be different from preferred() if it is overridden.
      **/
@@ -157,6 +161,8 @@ public:
      * Static function: Find the next occurrence of the shortcut marker ('&')
      * in a string, beginning at starting position start_pos.
      *
+     * An escaped "&&" does not count.
+     *
      * Returns string::npos if not found or the position of the shortcut marker
      * (not the shortcut character!) if found.
      **/
@@ -200,19 +206,25 @@ protected:
 
     // Data members
 
-    YWidget *	_widget;
-    std::string	_shortcutString;
-    bool	_shortcutStringCached;
+    YWidget *	_widget;               ///< (not owned)
+    std::string	_shortcutString;       ///< @see shortcutString
+    bool	_shortcutStringCached; ///< is _shortcutString initialized
 
     std::string	_cleanShortcutString;
-    bool	_cleanShortcutStringCached;
+    bool	_cleanShortcutStringCached; ///< always false :facepalm:
 
-    int		_preferred;	// int to enable initializing with invalid char (-1)
-    int		_shortcut;	// int to enable initializing with invalid char (-1)
+    /// char or 0 (none found) or -1 (not initialized yet)
+    /// @see preferred
+    int		_preferred;
+    /// char or 0 (none found) or -1 (not initialized yet)
+    /// @see shortcut
+    int		_shortcut;
 
-    bool	_conflict;
-    bool	_isButton;
-    bool	_isWizardButton;
+    bool	_conflict;       ///< @see conflict
+    bool	_isButton;       ///< @see isButton
+    bool	_isWizardButton; ///< @see isWizardButton
+    /// -1 means uninitialized
+    /// @see distinctShortcutChars
     int		_distinctShortcutChars;
 };
 

--- a/src/YShortcutManager.cc
+++ b/src/YShortcutManager.cc
@@ -29,6 +29,8 @@
 #include "YShortcutManager.h"
 #include "YDialog.h"
 #include "YDumbTab.h"
+#include "YItemSelector.h"
+#include "YMenuBar.h"
 
 using std::string;
 
@@ -377,6 +379,24 @@ YShortcutManager::clearShortcutList()
 }
 
 
+/**
+ * Try casting to any YSelectionWidget that has no shortcut associated but it should consider any
+ * shortcut of any item (e.g., YDumbTab, YItemSelector, YMenuBar).
+ **/
+YSelectionWidget * toSelectionWidget( YWidget * widget )
+{
+    YSelectionWidget * selectionWidget = dynamic_cast<YDumbTab *> (widget);
+
+    if ( ! selectionWidget )
+	selectionWidget = dynamic_cast<YItemSelector *> (widget);
+
+    if ( ! selectionWidget )
+	selectionWidget = dynamic_cast<YMenuBar *> (widget);
+
+    return selectionWidget;
+}
+
+
 void
 YShortcutManager::findShortcutWidgets( YWidgetListConstIterator begin,
 				       YWidgetListConstIterator end )
@@ -385,15 +405,15 @@ YShortcutManager::findShortcutWidgets( YWidgetListConstIterator begin,
     {
 	YWidget * widget = *it;
 
-	YDumbTab * dumbTab = dynamic_cast<YDumbTab *> (widget);
+	YSelectionWidget * selectionWidget = toSelectionWidget( widget );
 
-	if ( dumbTab )
+	if ( selectionWidget )
 	{
-	    for ( YItemConstIterator it = dumbTab->itemsBegin();
-		  it != dumbTab->itemsEnd();
+	    for ( YItemConstIterator it = selectionWidget->itemsBegin();
+		  it != selectionWidget->itemsEnd();
 		  ++it )
 	    {
-		YItemShortcut * shortcut = new YItemShortcut( dumbTab, *it );
+		YItemShortcut * shortcut = new YItemShortcut( selectionWidget, *it );
 		_shortcutList.push_back( shortcut );
 	    }
 	}

--- a/src/YShortcutManager.h
+++ b/src/YShortcutManager.h
@@ -144,7 +144,7 @@ protected:
     YDialog *_dialog;
 
     /**
-     * List of all the shortcuts in this dialog.
+     * List (owning) of all the shortcuts in this dialog.
      **/
     YShortcutList _shortcutList;
 
@@ -168,7 +168,7 @@ protected:
 
 private:
 
-    bool _didCheck;
+    bool _didCheck;             ///< has checkShortcuts been called?
 };
 
 


### PR DESCRIPTION
### Problem

A new menu bar widget was recently added. Most of the existing widgets only have one hotkey, but a menu bar should react to several hotkeys, that is, for the hotkey of every top level menu. The algorithm for resolving shortcut conflicts considers only one shortcut per widget. Because that, the shortcuts of the  menu options could conflict with the shortcuts of other widgets.

* PBI: https://trello.com/c/fCUBIGGg/2023-3-tw-p3-1175142-yast-menu-bar-toplevel-shortcut-conflicts
* https://bugzilla.suse.com/show_bug.cgi?id=1175142

### Solution

There already was some support for multiple shortcuts. It was added for the *YDumbTab* widget, which had a similar problem to the *YMenuBar* shortcuts. The *YItemSelector* widget was another case where shortcuts were not working because the widget has more than one shortcut. The good news is that all they descends from *YSelectionWidget*, so the current solution for *YDumbTab* was easily applied to *YMenuBar* and *YItemSelector* as well.

* See https://github.com/libyui/libyui-qt/pull/131.
* See https://github.com/libyui/libyui-ncurses/pull/101

#### Notes

* Due to some strange bug, the hotkeys are not highlighted in the *NCItemSelector* widget (ncurses version). We are trying to find the source of the problem.
* The changes in this PR imply to bump the so version, but this will be done when the *sprint-108* branch includes all the changes to do during this sprint.

### Screenshots

* With shortcuts conflicts (note that "Content" menu and "Close" are using the "c" hotkey):

![Screenshot from 2020-09-07 09-46-56](https://user-images.githubusercontent.com/1112304/92368685-f5ce2800-f0ef-11ea-864b-2b153a718fac.png)

* Without conflicts:

![Screenshot from 2020-09-07 09-47-41](https://user-images.githubusercontent.com/1112304/92368707-fb2b7280-f0ef-11ea-83f0-93f2550b76e9.png)

![Screenshot from 2020-09-07 09-48-21](https://user-images.githubusercontent.com/1112304/92368723-ff579000-f0ef-11ea-9229-1fe44faf5fea.png)
