### PR TITLE
Nested Items in Table Widgets

### DIFF
--- a/SOURCECONF.cmake
+++ b/SOURCECONF.cmake
@@ -211,4 +211,5 @@ SET( EXAMPLES_LIST
   SelectionBox2.cc
   SelectionBox3-many-items.cc
   Table-many-items.cc
+  Table-nested-items.cc
 )

--- a/VERSION.cmake
+++ b/VERSION.cmake
@@ -1,5 +1,5 @@
 SET( VERSION_MAJOR "3")
-SET( VERSION_MINOR "11" )
+SET( VERSION_MINOR "12" )
 SET( VERSION_PATCH "0" )
 SET( VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}${GIT_SHA1_VERSION}" )
 
@@ -8,7 +8,7 @@ SET( VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}${GIT_SHA1_VERSI
 # Currently you must also change so_version in libyui.spec
 # *and also in **all** other* libyui-*.spec files in the other repositories.
 # Yes, such a design is suboptimal.
-SET( SONAME_MAJOR "13" )
+SET( SONAME_MAJOR "14" )
 SET( SONAME_MINOR "0" )
 SET( SONAME_PATCH "0" )
 SET( SONAME "${SONAME_MAJOR}.${SONAME_MINOR}.${SONAME_PATCH}" )

--- a/examples/Table-many-items.cc
+++ b/examples/Table-many-items.cc
@@ -96,7 +96,8 @@ int main( int argc, char **argv )
     //
 
     YDialog    * dialog  = YUI::widgetFactory()->createPopupDialog();
-    YLayoutBox * vbox    = YUI::widgetFactory()->createVBox( dialog );
+    YAlignment * mbox    = YUI::widgetFactory()->createMarginBox( dialog, 1, 0.4 );
+    YLayoutBox * vbox    = YUI::widgetFactory()->createVBox( mbox );
 
     // Specify larger size for the Table: It can scroll, so its size
     // depends on other widgets in the layout.

--- a/examples/Table-nested-items.cc
+++ b/examples/Table-nested-items.cc
@@ -70,7 +70,7 @@ void createWidgets()
 
     dialog		 = fac->createPopupDialog();
     YAlignment * minSize = fac->createMinSize( dialog, 74, 15 );
-    YAlignment * mbox	 = fac->createMarginBox( minSize, 2, 2, 0.4, 0.4 );
+    YAlignment * mbox	 = fac->createMarginBox( minSize, 1, 0.4 );
     YLayoutBox * vbox	 = fac->createVBox( mbox );
     YAlignment * left    = fac->createLeft( vbox );
     fac->createHeading( left, "Storage Overview" );
@@ -101,23 +101,25 @@ YTableHeader * tableHeader()
 void populateTable()
 {
     yuiMilestone() << endl;
-    bool isOpen = true;
 
     YTableItem * sda = new YTableItem( "/dev/sda", "931.5G" );
-    new YTableItem( sda, isOpen, "/dev/sda1",  "97.7G", "ntfs", "/win/boot" );
-    new YTableItem( sda, isOpen, "/dev/sda2", "833.9G", "ntfs", "/win/app"  );
+    sda->setOpen();
+    new YTableItem( sda, "/dev/sda1",  "97.7G", "ntfs", "/win/boot" );
+    new YTableItem( sda, "/dev/sda2", "833.9G", "ntfs", "/win/app"  );
 
     YTableItem * sdb = new YTableItem( "/dev/sdb", "931.5G" );
-    new YTableItem( sdb, isOpen, "/dev/sdb1",   "2.0G", "swap" );
-    new YTableItem( sdb, isOpen, "/dev/sdb2",  "29.4G", "ext4", "/hd-root-leap-42"   );
-    new YTableItem( sdb, isOpen, "/dev/sdb3",  "29.4G", "ext4", "/hd-root-leap-15-0" );
-    new YTableItem( sdb, isOpen, "/dev/sdb4", "855.8G", "xfs",  "/work" );
+    sdb->setClosed();
+    new YTableItem( sdb, "/dev/sdb1",   "2.0G", "swap" );
+    new YTableItem( sdb, "/dev/sdb2",  "29.4G", "ext4", "/hd-root-leap-42"   );
+    new YTableItem( sdb, "/dev/sdb3",  "29.4G", "ext4", "/hd-root-leap-15-0" );
+    new YTableItem( sdb, "/dev/sdb4", "855.8G", "xfs",  "/work" );
 
     YTableItem * sdc = new YTableItem( "/dev/sdc", "232.9G" );
-    new YTableItem( sdc, isOpen, "/dev/sdc1",   "2.0G", "swap", "[swap]" );
-    new YTableItem( sdc, isOpen, "/dev/sdc2",  "29.4G", "ext4", "/ssd-root-leap-15-1" );
-    new YTableItem( sdc, isOpen, "/dev/sdc3",  "29.4G", "ext4", "/" );
-    new YTableItem( sdc, isOpen, "/dev/sdc4", "167.2G", "ext4", "/ssd-work" );
+    sdc->setOpen();
+    new YTableItem( sdc, "/dev/sdc1",   "2.0G", "swap", "[swap]" );
+    new YTableItem( sdc, "/dev/sdc2",  "29.4G", "ext4", "/ssd-root-leap-15-1" );
+    new YTableItem( sdc, "/dev/sdc3",  "29.4G", "ext4", "/" );
+    new YTableItem( sdc, "/dev/sdc4", "167.2G", "ext4", "/ssd-work" );
 
 
     // Using a YItemCollection is more efficient than adding each item one by one

--- a/examples/Table-nested-items.cc
+++ b/examples/Table-nested-items.cc
@@ -1,0 +1,156 @@
+/*
+  Copyright (c) [2020] SUSE LLC
+  This library is free software; you can redistribute it and/or modify
+  it under the terms of the GNU Lesser General Public License as
+  published by the Free Software Foundation; either version 2.1 of the
+  License, or (at your option) version 3.0 of the License. This library
+  is distributed in the hope that it will be useful, but WITHOUT ANY
+  WARRANTY; without even the implied warranty of MERCHANTABILITY or
+  FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public
+  License for more details. You should have received a copy of the GNU
+  Lesser General Public License along with this library; if not, write
+  to the Free Software Foundation, Inc., 51 Franklin Street, Fifth
+  Floor, Boston, MA 02110-1301 USA
+*/
+
+
+// Example for a Table widget with nested items.
+//
+// Compile with:
+//
+//     g++ -I/usr/include/yui -lyui Table-nested-items.cc -o Table-nested-items
+
+#define YUILogComponent "example"
+#include "YUILog.h"
+
+#include "YUI.h"
+#include "YWidgetFactory.h"
+#include "YDialog.h"
+#include "YTable.h"
+#include "YAlignment.h"
+#include "YLabel.h"
+#include "YLayoutBox.h"
+#include "YPushButton.h"
+#include "YEvent.h"
+
+
+using std::string;
+
+// Widgets
+
+YDialog		* dialog	= 0;
+YTable          * table         = 0;
+YPushButton	* closeButton	= 0;
+
+
+void createWidgets();
+YTableHeader * tableHeader();
+void populateTable();
+void handleEvents();
+
+
+int main( int argc, char **argv )
+{
+    YUILog::setLogFileName( "/tmp/libyui-examples.log" );
+    YUILog::enableDebugLogging();
+
+    createWidgets();
+    populateTable();
+    handleEvents();
+
+    dialog->destroy();
+}
+
+
+void createWidgets()
+{
+    yuiMilestone() << endl;
+
+    YWidgetFactory * fac = YUI::widgetFactory();
+
+    dialog		 = fac->createPopupDialog();
+    YAlignment * minSize = fac->createMinSize( dialog, 74, 15 );
+    YAlignment * mbox	 = fac->createMarginBox( minSize, 2, 2, 0.4, 0.4 );
+    YLayoutBox * vbox	 = fac->createVBox( mbox );
+    YAlignment * left    = fac->createLeft( vbox );
+    fac->createHeading( left, "Storage Overview" );
+    fac->createVSpacing( vbox, 0.2 );
+
+    table = fac->createTable( vbox, tableHeader() );
+    table->setNotify( true );
+    table->setImmediateMode( true );
+
+    fac->createVSpacing( vbox, 0.5 );
+    YAlignment * right = fac->createRight( vbox );
+    closeButton = fac->createPushButton( right, "&Close" );
+}
+
+
+YTableHeader * tableHeader()
+{
+    YTableHeader * header = new YTableHeader();
+    header->addColumn( "Device"      );
+    header->addColumn( "Size"        , YAlignEnd   );
+    header->addColumn( "Type"        );
+    header->addColumn( "Mount Point" );
+
+    return header;
+}
+
+
+void populateTable()
+{
+    yuiMilestone() << endl;
+    bool isOpen = true;
+
+    YTableItem * sda = new YTableItem( "/dev/sda", "931.5G" );
+    new YTableItem( sda, isOpen, "/dev/sda1",  "97.7G", "ntfs", "/win/boot" );
+    new YTableItem( sda, isOpen, "/dev/sda2", "833.9G", "ntfs", "/win/app"  );
+
+    YTableItem * sdb = new YTableItem( "/dev/sdb", "931.5G" );
+    new YTableItem( sdb, isOpen, "/dev/sdb1",   "2.0G", "swap" );
+    new YTableItem( sdb, isOpen, "/dev/sdb2",  "29.4G", "ext4", "/hd-root-leap-42"   );
+    new YTableItem( sdb, isOpen, "/dev/sdb3",  "29.4G", "ext4", "/hd-root-leap-15-0" );
+    new YTableItem( sdb, isOpen, "/dev/sdb4", "855.8G", "xfs",  "/work" );
+
+    YTableItem * sdc = new YTableItem( "/dev/sdc", "232.9G" );
+    new YTableItem( sdc, isOpen, "/dev/sdc1",   "2.0G", "swap", "[swap]" );
+    new YTableItem( sdc, isOpen, "/dev/sdc2",  "29.4G", "ext4", "/ssd-root-leap-15-1" );
+    new YTableItem( sdc, isOpen, "/dev/sdc3",  "29.4G", "ext4", "/" );
+    new YTableItem( sdc, isOpen, "/dev/sdc4", "167.2G", "ext4", "/ssd-work" );
+
+
+    // Using a YItemCollection is more efficient than adding each item one by one
+
+    YItemCollection items;
+    items.push_back( sda );
+    items.push_back( sdb );
+    items.push_back( sdc );
+
+    table->addItems( items );
+}
+
+
+void handleEvents()
+{
+    yuiMilestone() << endl;
+
+    while ( true )
+    {
+	YEvent * event = dialog->waitForEvent();
+
+	if ( event )
+	{
+	    if ( event->widget()    == closeButton ||
+		 event->eventType() == YEvent::CancelEvent ) // window manager "close window" button
+	    {
+		break; // leave event loop
+	    }
+
+	    if ( event->widget() == table )	   // the table will only send events with setNotify()
+	    {
+                yuiMilestone() << "Event from the table" << endl;
+	    }
+	}
+    }
+}

--- a/package/libyui-doc.spec
+++ b/package/libyui-doc.spec
@@ -17,10 +17,10 @@
 
 
 %define parent libyui
-%define so_version 13
+%define so_version 14
 
 Name:           %{parent}-doc
-Version:        3.11.0
+Version:        3.12.0
 Release:        0
 Source:         %{parent}-%{version}.tar.bz2
 

--- a/package/libyui.changes
+++ b/package/libyui.changes
@@ -1,4 +1,15 @@
 -------------------------------------------------------------------
+Thu Oct  8 15:20:24 UTC 2020 - José Iván López González <jlopez@suse.com>
+
+- Resolve hotkeys conflicts for widgets with multiple hotkeys
+  (related to bsc#1175489).
+- Allow to show/hide menus and menu items (related to
+  manatools/libyui-mga#1).
+- Allow nested items in tables (bsc#1176402).
+- Bumped SO version to 14.
+- 3.12.0
+
+-------------------------------------------------------------------
 Tue Aug 11 13:26:18 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Added MenuBar widget (bsc#1175115)

--- a/package/libyui.spec
+++ b/package/libyui.spec
@@ -16,11 +16,11 @@
 #
 
 Name:           libyui
-Version:        3.11.0
+Version:        3.12.0
 Release:        0
 Source:         %{name}-%{version}.tar.bz2
 
-%define so_version 13
+%define so_version 14
 %define bin_name %{name}%{so_version}
 
 # optionally build with code coverage reporting,

--- a/src/YApplication.h
+++ b/src/YApplication.h
@@ -82,7 +82,10 @@ public:
      **/
     virtual void setIconBasePath( const std::string & newIconBasePath );
 
-    YIconLoader *iconLoader();
+    /**
+     * Return the icon loader.
+     **/
+    YIconLoader * iconLoader();
 
     /**
      * Return the default function key number for a widget with the specified
@@ -180,7 +183,7 @@ public:
      * Derived classes are required to implement this.
      **/
     virtual std::string askForExistingDirectory( const std::string & startDir,
-					    const std::string & headline ) = 0;
+                                                 const std::string & headline ) = 0;
 
     /**
      * Open a file selection box and prompt the user for an existing file.
@@ -199,8 +202,8 @@ public:
      * Derived classes are required to implement this.
      **/
     virtual std::string askForExistingFile( const std::string & startWith,
-				       const std::string & filter,
-				       const std::string & headline ) = 0;
+                                            const std::string & filter,
+                                            const std::string & headline ) = 0;
 
     /**
      * Open a file selection box and prompt the user for a file to save data
@@ -221,8 +224,8 @@ public:
      * Derived classes are required to implement this.
      **/
     virtual std::string askForSaveFileName( const std::string & startWith,
-				       const std::string & filter,
-				       const std::string & headline ) = 0;
+                                            const std::string & filter,
+                                            const std::string & headline ) = 0;
 
     /**
      * Open a context menu for a widget

--- a/src/YBarGraph.cc
+++ b/src/YBarGraph.cc
@@ -46,7 +46,7 @@ using std::string;
 			   0,	    /* min */				\
 		           (int) priv->segments.size() - 1  ) ); /* max */ \
 	}								\
-    } while( 0 )
+    } while ( 0 )
 
 
 

--- a/src/YBarGraph.h
+++ b/src/YBarGraph.h
@@ -138,7 +138,7 @@ public:
      * 'false' if that value requires special handling (not in error cases:
      * those are covered by exceptions).
      **/
-    virtual bool setProperty( const std::string & propertyName,
+    virtual bool setProperty( const std::string    & propertyName,
 			      const YPropertyValue & val );
 
     /**

--- a/src/YBuiltinCaller.h
+++ b/src/YBuiltinCaller.h
@@ -37,9 +37,11 @@
 class YBuiltinCaller
 {
 protected:
+
     YBuiltinCaller() {}
 
 public:
+
     virtual ~YBuiltinCaller() {}
 
     /**

--- a/src/YBusyIndicator.h
+++ b/src/YBusyIndicator.h
@@ -42,9 +42,9 @@ protected:
      * Constructor.
      **/
     YBusyIndicator( YWidget * 		parent,
-		  const std::string &	label,
-		  int			timeout = 1000,
-		  bool 			alive = true );
+                    const std::string &	label,
+                    int			timeout = 1000,
+                    bool 		alive = true );
 
 public:
     /**
@@ -111,7 +111,7 @@ public:
      * 'false' if that value requires special handling (not in error cases:
      * those are covered by exceptions).
      **/
-    virtual bool setProperty( const std::string & propertyName,
+    virtual bool setProperty( const std::string    & propertyName,
 			      const YPropertyValue & val );
 
     /**

--- a/src/YCheckBox.h
+++ b/src/YCheckBox.h
@@ -155,7 +155,7 @@ public:
      * 'false' if that value requires special handling (not in error cases:
      * those are covered by exceptions).
      **/
-    virtual bool setProperty( const std::string & propertyName,
+    virtual bool setProperty( const std::string    & propertyName,
 			      const YPropertyValue & val );
 
     /**

--- a/src/YCheckBoxFrame.h
+++ b/src/YCheckBoxFrame.h
@@ -159,7 +159,7 @@ public:
      * 'false' if that value requires special handling (not in error cases:
      * those are covered by exceptions).
      **/
-    virtual bool setProperty( const std::string & propertyName,
+    virtual bool setProperty( const std::string    & propertyName,
 			      const YPropertyValue & val );
 
     /**

--- a/src/YComboBox.h
+++ b/src/YComboBox.h
@@ -185,7 +185,7 @@ public:
      * 'false' if that value requires special handling (not in error cases:
      * those are covered by exceptions).
      **/
-    virtual bool setProperty( const std::string & propertyName,
+    virtual bool setProperty( const std::string    & propertyName,
 			      const YPropertyValue & val );
 
     /**

--- a/src/YContextMenu.h
+++ b/src/YContextMenu.h
@@ -131,7 +131,7 @@ public:
      * 'false' if that value requires special handling (not in error cases:
      * those are covered by exceptions).
      **/
-    virtual bool setProperty( const std::string & propertyName,
+    virtual bool setProperty( const std::string    & propertyName,
 			      const YPropertyValue & val );
 
     /**

--- a/src/YDownloadProgress.h
+++ b/src/YDownloadProgress.h
@@ -130,7 +130,7 @@ public:
      * 'false' if that value requires special handling (not in error cases:
      * those are covered by exceptions).
      **/
-    virtual bool setProperty( const std::string & propertyName,
+    virtual bool setProperty( const std::string    & propertyName,
 			      const YPropertyValue & val );
 
     /**

--- a/src/YDumbTab.h
+++ b/src/YDumbTab.h
@@ -80,7 +80,7 @@ public:
      * 'false' if that value requires special handling (not in error cases:
      * those are covered by exceptions).
      **/
-    virtual bool setProperty( const std::string & propertyName,
+    virtual bool setProperty( const std::string    & propertyName,
 			      const YPropertyValue & val );
 
     /**

--- a/src/YEvent.h
+++ b/src/YEvent.h
@@ -215,7 +215,7 @@ public:
      * currently has the keyboard focus.
      **/
     YKeyEvent( const std::string &	keySymbol,
-	       YWidget *	focusWidget = 0 );
+	       YWidget *                focusWidget = 0 );
 
     /**
      * Returns the key symbol - a text describing the

--- a/src/YExternalWidgets.h
+++ b/src/YExternalWidgets.h
@@ -55,7 +55,7 @@ public:
      * externalWidgets try loading it (exactly as YUI::ui does) with default function symbol
      * to be executed (see YUILoader::loadExternalWidgets for explanation)
      **/
-    static YExternalWidgets * externalWidgets(const std::string& name);
+    static YExternalWidgets * externalWidgets( const std::string & name );
 
     /**
      * Return the external widget factory that provides all the createXY() methods for
@@ -76,8 +76,8 @@ public:
      * yui-foo-qt plugin implementation.
      *
      **/
-    YExternalWidgetFactory * externalWidgetFactory();
-    static YExternalWidgetFactory * externalWidgetFactory(const std::string& name);
+    YExternalWidgetFactory        * externalWidgetFactory();
+    static YExternalWidgetFactory * externalWidgetFactory( const std::string & name );
 
 protected:
 
@@ -91,10 +91,11 @@ protected:
     virtual YExternalWidgetFactory * createExternalWidgetFactory() = 0;
 
 private:
-    /** Externale widgets plugin name */
+
+    /** External widgets plugin name */
     std::string _name;
 
-    /** Externale widget factory */
+    /** External widget factory */
     YExternalWidgetFactory* _factory;
 
     /** plugin instances */

--- a/src/YFrame.h
+++ b/src/YFrame.h
@@ -81,7 +81,7 @@ public:
      * 'false' if that value requires special handling (not in error cases:
      * those are covered by exceptions).
      **/
-    virtual bool setProperty( const std::string & propertyName,
+    virtual bool setProperty( const std::string    & propertyName,
 			      const YPropertyValue & val );
 
     /**

--- a/src/YGraph.h
+++ b/src/YGraph.h
@@ -86,7 +86,7 @@ public:
      * 'false' if that value requires special handling (not in error cases:
      * those are covered by exceptions).
      **/
-    virtual bool setProperty( const std::string & propertyName,
+    virtual bool setProperty( const std::string    & propertyName,
 			      const YPropertyValue & val );
 
     /**

--- a/src/YGraphPlugin.h
+++ b/src/YGraphPlugin.h
@@ -58,7 +58,8 @@ public:
      * This might return 0 if the plugin lib could not be loaded or if the
      * appropriate symbol could not be located in the plugin lib.
      **/
-    virtual YGraph * createGraph( YWidget * parent, const std::string & filename,
+    virtual YGraph * createGraph( YWidget           * parent,
+                                  const std::string & filename,
 				  const std::string & layoutAlgorithm ) = 0;
 };
 

--- a/src/YIconLoader.cc
+++ b/src/YIconLoader.cc
@@ -85,7 +85,7 @@ string YIconLoader::findIcon( string name )
 	fullPath = _iconBasePath + name;
 	if ( fileExists ( fullPath ) )
 	{
-	    yuiMilestone() << "Found " << name << " in global search path" << endl;
+	    // yuiMilestone() << "Found " << name << " in global search path" << endl;
 	    return fullPath;
 	}
     }
@@ -104,11 +104,11 @@ string YIconLoader::findIcon( string name )
 
 	if ( fileExists( fullPath ) )
 	{
-	    yuiMilestone() << "Found " << name << " in " <<  *listIt << " search path" << endl;
+	    // yuiMilestone() << "Found " << name << " in " <<  *listIt << " search path" << endl;
 	    return fullPath;
 	}
 
-	yuiMilestone() <<  name << " not found in " <<	*listIt << " search path, skipping" << endl;
+	yuiDebug() <<  name << " not found in " << *listIt << " search path, skipping" << endl;
 	listIt++;
     }
 

--- a/src/YIconLoader.cc
+++ b/src/YIconLoader.cc
@@ -62,19 +62,19 @@ string YIconLoader::iconBasePath() const
 
 void YIconLoader::addIconSearchPath( string path )
 {
-    icon_dirs.push_front( path );
+    _iconDirs.push_front( path );
 }
 
 
 string YIconLoader::findIcon( string name )
 {
     // No extension -> add some
-    string::size_type loc = name.find(".png");
+    string::size_type loc = name.find( ".png" );
     if ( loc == string::npos )
 	name += ".png";
 
     // Absolute path -> return it
-    if (name[0] == '/')
+    if ( name[0] == '/' )
 	return name;
 
     string fullPath;
@@ -91,9 +91,9 @@ string YIconLoader::findIcon( string name )
     }
 
     // Now search the fallback dirs
-    std::list<string>::iterator listIt = icon_dirs.begin();
+    std::list<string>::iterator listIt = _iconDirs.begin();
 
-    while( listIt != icon_dirs.end() )
+    while ( listIt != _iconDirs.end() )
     {
 	// Something like relative path
 	if ( name.find('/') != string::npos )
@@ -119,7 +119,7 @@ string YIconLoader::findIcon( string name )
 bool YIconLoader::fileExists( string fname )
 {
     struct stat fileInfo;
-    int ret = stat (fname.c_str(), &fileInfo);
+    int ret = stat( fname.c_str(), &fileInfo );
 
-    return ( ret == 0 );
+    return ret == 0;
 }

--- a/src/YIconLoader.h
+++ b/src/YIconLoader.h
@@ -38,8 +38,8 @@ public:
 
     std::string findIcon( std::string name );
 
-    //FIXME: these two are here for compatibility reasons
-    // deprecate them in due course and treat base path just
+    // FIXME: these two are here for compatibility reasons.
+    // Deprecate them in due course and treat base path just
     // like any other search path
     void setIconBasePath( std::string path );
     std::string iconBasePath() const;
@@ -48,8 +48,8 @@ public:
 
 private:
 
-    std::string		_iconBasePath;
-    std::list <std::string>	icon_dirs;
+    std::string                 _iconBasePath;
+    std::list <std::string>	_iconDirs;
 
     bool fileExists( std::string fname );
 };

--- a/src/YInputField.h
+++ b/src/YInputField.h
@@ -159,7 +159,7 @@ public:
      * 'false' if that value requires special handling (not in error cases:
      * those are covered by exceptions).
      **/
-    virtual bool setProperty( const std::string & propertyName,
+    virtual bool setProperty( const std::string    & propertyName,
 			      const YPropertyValue & val );
 
     /**

--- a/src/YIntField.h
+++ b/src/YIntField.h
@@ -145,7 +145,7 @@ public:
      * 'false' if that value requires special handling (not in error cases:
      * those are covered by exceptions).
      **/
-    virtual bool setProperty( const std::string & propertyName,
+    virtual bool setProperty( const std::string    & propertyName,
 			      const YPropertyValue & val );
 
     /**

--- a/src/YItem.cc
+++ b/src/YItem.cc
@@ -22,7 +22,14 @@
 
 /-*/
 
+#define MAX_DEBUG_LABEL_LEN	32
+
+
+#include <iostream>
 #include "YItem.h"
+
+using std::string;
+
 
 /**
  * Static children collection that is always empty so the children
@@ -31,3 +38,36 @@
  * No item will ever be added to this collection.
  **/
 YItemCollection YItem::_noChildren;
+
+
+string
+YItem::debugLabel() const
+{
+    return limitLength( _label, MAX_DEBUG_LABEL_LEN );
+}
+
+
+string
+YItem::limitLength( const string & origText, int limit ) const
+{
+    string text = origText;
+
+    if ( text.size() > MAX_DEBUG_LABEL_LEN )
+    {
+	text.resize( MAX_DEBUG_LABEL_LEN );
+	text.append( "..." );
+    }
+
+    return text;
+}
+
+
+std::ostream & operator<<( std::ostream & stream, const YItem * item )
+{
+    if ( item )
+        stream << "<" << item->itemClass() << " " << item->debugLabel() << ">";
+    else
+        stream << "<NULL YItem>";
+
+    return stream;
+}

--- a/src/YItem.h
+++ b/src/YItem.h
@@ -47,6 +47,9 @@ typedef YItemCollection::const_iterator		YItemConstIterator;
 /**
  * Simple item class for SelectionBox, ComboBox, MultiSelectionBox etc. items.
  * This class provides stubs for children management.
+ *
+ * See also
+ * https://github.com/libyui/libyui-ncurses/blob/master/doc/nctable-and-nctree.md
  **/
 class YItem
 {

--- a/src/YItem.h
+++ b/src/YItem.h
@@ -54,7 +54,8 @@ public:
     /**
      * Constructor with just the label and optionally the selected state.
      **/
-    YItem( const std::string & label, bool selected = false )
+    YItem( const std::string & label,
+           bool                selected = false )
 	: _label( label )
 	, _status( selected ? 1 : 0 )
 	, _index( -1 )
@@ -64,7 +65,9 @@ public:
     /**
      * Constructor with label and icon name and optionally the selected state.
      **/
-    YItem( const std::string & label, const std::string & iconName, bool selected = false )
+    YItem( const std::string & label,
+           const std::string & iconName,
+           bool                selected = false )
 	: _label( label )
 	, _iconName( iconName )
 	, _status( selected ? 1 : 0 )

--- a/src/YItem.h
+++ b/src/YItem.h
@@ -27,6 +27,7 @@
 
 #include <string>
 #include <vector>
+#include <iosfwd>
 
 
 class YItem;
@@ -82,6 +83,12 @@ public:
      * Destructor.
      **/
     virtual ~YItem() {}
+
+    /**
+     * Returns a descriptive name of this widget class for logging,
+     * debugging etc.
+     **/
+    virtual const char * itemClass() const { return "YItem"; }
 
     /**
      * Return this item's label. This is what the user sees in a dialog, so
@@ -204,11 +211,23 @@ public:
     virtual YItemConstIterator	childrenEnd() const	{ return _noChildren.end(); }
 
     /**
-     * Returns this item's parent item or 0 if it is a toplevel item.
+     * Return this item's parent item or 0 if it is a toplevel item.
      * This default implementation always returns 0.
      * Derived classes that handle children should reimplement this.
      **/
     virtual YItem * parent() const { return 0; }
+
+    /**
+     * Return a descriptive label of this item instance for debugging.
+     * This might be truncated if the original label is too long.
+     **/
+    virtual std::string debugLabel() const;
+
+    /**
+     * Return a string of maximum 'limit' characters. Add an ellipsis ("...")
+     * if it was truncated.
+     **/
+    std::string limitLength( const std::string & text, int limit ) const;
 
 
 private:
@@ -225,6 +244,9 @@ private:
      **/
     static YItemCollection _noChildren;
 };
+
+
+std::ostream & operator<<( std::ostream & stream, const YItem * item );
 
 
 

--- a/src/YItemSelector.h
+++ b/src/YItemSelector.h
@@ -161,7 +161,7 @@ public:
      * 'false' if that value requires special handling (not in error cases:
      * those are covered by exceptions).
      **/
-    virtual bool setProperty( const std::string &    propertyName,
+    virtual bool setProperty( const std::string    & propertyName,
 			      const YPropertyValue & val );
 
     /**

--- a/src/YLabel.h
+++ b/src/YLabel.h
@@ -156,7 +156,7 @@ public:
      * 'false' if that value requires special handling (not in error cases:
      * those are covered by exceptions).
      **/
-    virtual bool setProperty( const std::string & propertyName,
+    virtual bool setProperty( const std::string    & propertyName,
 			      const YPropertyValue & val );
 
     /**

--- a/src/YLogView.h
+++ b/src/YLogView.h
@@ -151,7 +151,7 @@ public:
      * 'false' if that value requires special handling (not in error cases:
      * those are covered by exceptions).
      **/
-    virtual bool setProperty( const std::string & propertyName,
+    virtual bool setProperty( const std::string    & propertyName,
 			      const YPropertyValue & val );
 
     /**

--- a/src/YMenuWidget.cc
+++ b/src/YMenuWidget.cc
@@ -279,11 +279,11 @@ YMenuWidget::findItem( std::vector<std::string>::iterator path_begin,
 
         if ( item->label() == *path_begin )
         {
-            if ( std::next(path_begin) == path_end )
+            if ( std::next( path_begin ) == path_end )
             {
                 // Only return items which can trigger an action.
                 // Intermediate items only open a submenu, so continue looking.
-                if( item->hasChildren() )
+                if ( item->hasChildren() )
                     continue;
 
                 return item;

--- a/src/YMenuWidget.cc
+++ b/src/YMenuWidget.cc
@@ -30,6 +30,8 @@
 #include "YShortcut.h"
 #include "YMenuWidget.h"
 
+#define VERBOSE_SHORTCUTS       0
+
 
 using std::string;
 
@@ -163,6 +165,7 @@ YMenuWidget::resolveShortcutConflicts( YItemConstIterator begin,
                                        YItemConstIterator end )
 {
 #define USED_SIZE ((int) sizeof( char ) << 8)
+
     bool used[ USED_SIZE ];
 
     for ( int i = 0; i < USED_SIZE; i++ )
@@ -189,17 +192,21 @@ YMenuWidget::resolveShortcutConflicts( YItemConstIterator begin,
             if ( shortcut == 0 )
             {
                 conflicts.push_back(item);
+
+#if VERBOSE_SHORTCUTS
                 yuiMilestone() << "No or invalid shortcut found: \""
                                << item->label() << "\""
                                << endl;
+#endif
             }
             else if ( used[ (unsigned) shortcut ] )
             {
                 conflicts.push_back(item);
-
+#if VERBOSE_SHORTCUTS
                 yuiWarning() << "Conflicting shortcut found: \""
                              << item->label() << "\""
                              << endl;
+#endif
             }
             else
             {
@@ -238,7 +245,10 @@ YMenuWidget::resolveShortcutConflicts( YItemConstIterator begin,
         if ( new_c != 0 )
         {
             clean.insert( index, 1, YShortcut::shortcutMarker() );
-            yuiMilestone() << "New label used: " << clean << endl;
+
+#if VERBOSE_SHORTCUTS
+            yuiDebug() << "New label used: " << clean << endl;
+#endif
         }
 
         i->setLabel( clean );

--- a/src/YMultiLineEdit.h
+++ b/src/YMultiLineEdit.h
@@ -134,7 +134,7 @@ public:
      * 'false' if that value requires special handling (not in error cases:
      * those are covered by exceptions).
      **/
-    virtual bool setProperty( const std::string & propertyName,
+    virtual bool setProperty( const std::string    & propertyName,
 			      const YPropertyValue & val );
 
     /**

--- a/src/YMultiProgressMeter.h
+++ b/src/YMultiProgressMeter.h
@@ -137,7 +137,7 @@ public:
      * 'false' if that value requires special handling (not in error cases:
      * those are covered by exceptions).
      **/
-    virtual bool setProperty( const std::string & propertyName,
+    virtual bool setProperty( const std::string    & propertyName,
 			      const YPropertyValue & val );
 
     /**

--- a/src/YMultiSelectionBox.h
+++ b/src/YMultiSelectionBox.h
@@ -77,7 +77,7 @@ public:
      * 'false' if that value requires special handling (not in error cases:
      * those are covered by exceptions).
      **/
-    virtual bool setProperty( const std::string & propertyName,
+    virtual bool setProperty( const std::string    & propertyName,
 			      const YPropertyValue & val );
 
     /**

--- a/src/YOptionalWidgetFactory.h
+++ b/src/YOptionalWidgetFactory.h
@@ -99,7 +99,7 @@ public:
     virtual YMultiProgressMeter *	createMultiProgressMeter ( YWidget * parent, YUIDimension dim, const std::vector<float> & maxValues );
 
     virtual bool			hasPartitionSplitter();
-    virtual YPartitionSplitter *	createPartitionSplitter	( YWidget * 		parent,
+    virtual YPartitionSplitter *	createPartitionSplitter ( YWidget * 		parent,
 								  int 			usedSize,
 								  int 			totalFreeSize,
 								  int 			newPartSize,
@@ -122,9 +122,9 @@ public:
     YWidget *				createDummySpecialWidget( YWidget * parent );
 
     virtual bool                        hasTimezoneSelector();
-    virtual YTimezoneSelector *         createTimezoneSelector( YWidget *                                 parent,
-								const std::string &                       timezoneMap,
-								const std::map<std::string,std::string> & timezones );
+    virtual YTimezoneSelector *         createTimezoneSelector  ( YWidget *                                 parent,
+                                                                  const std::string &                       timezoneMap,
+                                                                  const std::map<std::string,std::string> & timezones );
 
     virtual bool			hasGraph();
 

--- a/src/YPartitionSplitter.h
+++ b/src/YPartitionSplitter.h
@@ -154,7 +154,7 @@ public:
      * 'false' if that value requires special handling (not in error cases:
      * those are covered by exceptions).
      **/
-    virtual bool setProperty( const std::string & propertyName,
+    virtual bool setProperty( const std::string    & propertyName,
 			      const YPropertyValue & val );
 
     /**

--- a/src/YPath.cc
+++ b/src/YPath.cc
@@ -50,7 +50,7 @@ using std::vector;
 
 YPath::YPath ( const string & directory, const string & filename )
 {
-    yuiDebug() << "Given filename: " << filename << endl;
+    // yuiDebug() << "Given filename: " << filename << endl;
 
     bool	   isThemeDir	     = ! directory.compare ( THEMEDIR );
     string	   progSubDir	     = YSettings::progDir ();
@@ -66,9 +66,9 @@ YPath::YPath ( const string & directory, const string & filename )
     if ( hasSubDirPrepend )
 	subDirPrepend = filename.substr ( 0, splitPos );
 
-    yuiDebug() << "Preferring subdir: "	      << progSubDir << endl;
-    yuiDebug() << "Subdir given with filename: " << subDirPrepend << endl;
-    yuiDebug() << "Looking for: "		      << filenameNoPrepend << endl;
+    // yuiDebug() << "Preferring subdir: "	    << progSubDir << endl;
+    // yuiDebug() << "Subdir given with filename: " << subDirPrepend << endl;
+    // yuiDebug() << "Looking for: "		    << filenameNoPrepend << endl;
 
     if ( hasSubDirPrepend )	// prefer subdir prepended to filename
     {
@@ -123,10 +123,12 @@ YPath::YPath ( const string & directory, const string & filename )
     }
 
     if ( fullPath.compare( "" ) != 0 )
-	yuiDebug() << "Found " << filenameNoPrepend << " in " << dir() << endl;
+    {
+	// yuiDebug() << "Found " << filenameNoPrepend << " in " << dir() << endl;
+    }
     else
     {
-	yuiDebug() << "Could NOT find " << filename << " by looking recursive inside " << directory << endl;
+	// yuiDebug() << "Could NOT find " << filename << " by looking recursive inside " << directory << endl;
 	fullPath = filename;
     }
 }
@@ -145,7 +147,7 @@ vector<string> YPath::lsDir( const string & directory )
 
     if ( ( dir = opendir( directory.c_str () ) ) != NULL )
     {
-	yuiDebug() << "Looking in " << directory << endl;
+	// yuiDebug() << "Looking in " << directory << endl;
 
 	while ( ( ent = readdir( dir ) ) != NULL )
 	    fileList.push_back( ent -> d_name );

--- a/src/YPath.cc
+++ b/src/YPath.cc
@@ -122,7 +122,7 @@ YPath::YPath ( const string & directory, const string & filename )
 	}
     }
 
-    if( fullPath.compare( "" ) != 0 )
+    if ( fullPath.compare( "" ) != 0 )
 	yuiDebug() << "Found " << filenameNoPrepend << " in " << dir() << endl;
     else
     {

--- a/src/YPath.h
+++ b/src/YPath.h
@@ -45,36 +45,39 @@ class YPath
 
 public:
 
-/**
- * Constructor
- *
- * to be called with the directory where to look inside
- * and filename which to lookup.
- *
- * YSettings::progSubDir will be preferred by the lookup.
- **/
-  YPath( const std::string & directory, const std::string & filename );
-/**
- * Destructor
- **/
-  ~YPath();
-/**
- * Returns the full path of the file if found;
- * if not found just the filename given in constructor.
- **/
-  std::string path();
-/**
- * Returns the directory where the file is found;
- * if not found just the subdir part (if there's any) of
- * the filename given in constructor.
- **/
-  std::string dir();
+    /**
+     * Constructor
+     *
+     * to be called with the directory where to look inside
+     * and filename which to lookup.
+     *
+     * YSettings::progSubDir will be preferred by the lookup.
+     **/
+    YPath( const std::string & directory,
+           const std::string & filename );
+    /**
+     * Destructor
+     **/
+    ~YPath();
+
+    /**
+     * Returns the full path of the file if found;
+     * if not found just the filename given in constructor.
+     **/
+    std::string path();
+
+    /**
+     * Returns the directory where the file is found;
+     * if not found just the subdir part (if there's any) of
+     * the filename given in constructor.
+     **/
+    std::string dir();
 
 private:
 
-  std::vector<std::string> lsDir( const std::string & directory );
-  std::string lookRecursive( const std::string & directory, const std::string & filename );
-  std::string fullPath;
+    std::vector<std::string> lsDir( const std::string & directory );
+    std::string lookRecursive( const std::string & directory, const std::string & filename );
+    std::string fullPath;
 
 };
 

--- a/src/YProgressBar.h
+++ b/src/YProgressBar.h
@@ -97,7 +97,7 @@ public:
      * 'false' if that value requires special handling (not in error cases:
      * those are covered by exceptions).
      **/
-    virtual bool setProperty( const std::string & propertyName,
+    virtual bool setProperty( const std::string    & propertyName,
 			      const YPropertyValue & val );
 
     /**

--- a/src/YPropertyEditor.h
+++ b/src/YPropertyEditor.h
@@ -36,8 +36,11 @@ public:
      * Constructor
      * @param  widget the target widget
      */
-    YPropertyEditor(YWidget * widget);
+    YPropertyEditor( YWidget * widget );
 
+    /**
+     * Destructor
+     **/
     virtual ~YPropertyEditor();
 
     /**
@@ -45,7 +48,7 @@ public:
      * @param  property name of the property to edit
      * @return true if the property has been changed, false otherwise
      */
-    bool edit(const std::string &property);
+    bool edit( const std::string & property );
 
 private:
 

--- a/src/YPushButton.h
+++ b/src/YPushButton.h
@@ -181,7 +181,7 @@ public:
      * 'false' if that value requires special handling (not in error cases:
      * those are covered by exceptions).
      **/
-    virtual bool setProperty( const std::string & propertyName,
+    virtual bool setProperty( const std::string    & propertyName,
 			      const YPropertyValue & val );
 
     /**

--- a/src/YRadioButton.h
+++ b/src/YRadioButton.h
@@ -142,7 +142,7 @@ public:
      * 'false' if that value requires special handling (not in error cases:
      * those are covered by exceptions).
      **/
-    virtual bool setProperty( const std::string & propertyName,
+    virtual bool setProperty( const std::string    & propertyName,
 			      const YPropertyValue & val );
 
     /**
@@ -183,7 +183,9 @@ public:
      **/
     const char * userInputProperty() { return YUIProperty_Value; }
 
+
 protected:
+
     /**
      * Traverse the widget hierarchy upwards to find the corresponding
      * YRadioButtonGroup, i.e. the class that controls the radio box behaviour
@@ -198,7 +200,7 @@ protected:
      * Reimplemented from YWidget because only radio buttons that are on (no
      * more than one per radio box) are recorded.
      **/
-    virtual void saveUserInput( YMacroRecorder *macroRecorder );
+    virtual void saveUserInput( YMacroRecorder * macroRecorder );
 
 private:
 

--- a/src/YRadioButtonGroup.h
+++ b/src/YRadioButtonGroup.h
@@ -108,7 +108,7 @@ public:
      * 'false' if that value requires special handling (not in error cases:
      * those are covered by exceptions).
      **/
-    virtual bool setProperty( const std::string & propertyName,
+    virtual bool setProperty( const std::string    & propertyName,
 			      const YPropertyValue & val );
 
     /**

--- a/src/YRichText.h
+++ b/src/YRichText.h
@@ -140,7 +140,7 @@ public:
      * 'false' if that value requires special handling (not in error cases:
      * those are covered by exceptions).
      **/
-    virtual bool setProperty( const std::string & propertyName,
+    virtual bool setProperty( const std::string    & propertyName,
 			      const YPropertyValue & val );
 
     /**
@@ -173,11 +173,10 @@ public:
      *
      * The special values are:
      *
-     * "minimum" Moves the scrollbar to the start.
+     * "minimum": Moves the scrollbar to the start.
+     * "maximum": Moves the scrollbar to the end.
      *
-     * "maximum" Moves the scrollbar to the end.
-     *
-     * Might not be available in all frontends.
+     * This might not be available in all frontends.
      */
     virtual void setVScrollValue( const std::string & newValue );
 
@@ -195,9 +194,8 @@ public:
      *
      * The special values are:
      *
-     * "minimum" Moves the scrollbar to the start.
-     *
-     * "maximum" Moves the scrollbar to the end.
+     * "minimum": Moves the scrollbar to the start.
+     * "maximum": Moves the scrollbar to the end.
      *
      * The meaning of start and end can depend on the text direction
      * (LTR or RTL).

--- a/src/YSelectionBox.h
+++ b/src/YSelectionBox.h
@@ -123,8 +123,8 @@ public:
      * 'false' if that value requires special handling (not in error cases:
      * those are covered by exceptions).
      **/
-    virtual bool setProperty( const std::string &       propertyName,
-			      const YPropertyValue &    val );
+    virtual bool setProperty( const std::string    & propertyName,
+			      const YPropertyValue & val );
 
     /**
      * Get a property.

--- a/src/YSelectionWidget.h
+++ b/src/YSelectionWidget.h
@@ -282,7 +282,7 @@ public:
 
     /**
      * Notification that any shortcut of any item was changed by the shortcut
-     * conflict manager.
+     * conflict manager YShortcutManager.
      *
      * Derived classes should reimplement this.
      **/

--- a/src/YSelectionWidget.h
+++ b/src/YSelectionWidget.h
@@ -38,6 +38,9 @@ class YSelectionWidgetPrivate;
  *   - YTable
  *   - YTree
  *   - YDumbTab
+ *
+ * See also
+ * https://github.com/libyui/libyui-ncurses/blob/master/doc/nctable-and-nctree.md
  **/
 class YSelectionWidget : public YWidget
 {

--- a/src/YSelectionWidget.h
+++ b/src/YSelectionWidget.h
@@ -281,7 +281,8 @@ public:
     bool enforceSingleSelection() const;
 
     /**
-     * Notification that any shortcut of any item was changed by the shortcut conflict manager.
+     * Notification that any shortcut of any item was changed by the shortcut
+     * conflict manager.
      *
      * Derived classes should reimplement this.
      **/
@@ -290,8 +291,9 @@ public:
     /**
      * Get the string of this widget that holds the keyboard shortcut.
      *
-     * Notice that some sub-classes (e.g., YDumbTab, YItemSelection, YMenuBar) has one shortcut for each
-     * item. This value is not meaningful for such widget classes.
+     * Notice that some sub-classes (e.g., YDumbTab, YItemSelection, YMenuBar)
+     * has one shortcut for each item. This value is not meaningful for such
+     * widget classes.
      *
      * Check YItemShortcut in YShortcut.{cc,h} for more details.
      *
@@ -302,14 +304,16 @@ public:
     /**
      * Set the string of this widget that holds the keyboard shortcut.
      *
-     * Also trigger a shortcutChanged() notification. This is useful for derived sub-classes to
-     * refresh the widget when any shortcut of any item was changed by the shortcut conflict manager.
+     * Also trigger a shortcutChanged() notification. This is useful for
+     * derived sub-classes to refresh the widget when any shortcut of any item
+     * was changed by the shortcut conflict manager.
      *
      * Check YItemShortcut in YShortcut.{cc,h} for more details.
      *
      * Reimplemented from YWidget.
      **/
     virtual void setShortcutString( const std::string & str );
+
 
 protected:
 

--- a/src/YSelectionWidget.h
+++ b/src/YSelectionWidget.h
@@ -105,7 +105,7 @@ public:
      **/
     void addItem( const std::string & itemLabel,
 		  const std::string & iconName,
-		  bool  selected = false );
+		  bool                selected = false );
 
     /**
      * Add multiple items. For some UIs, this can be more efficient than

--- a/src/YSettings.cc
+++ b/src/YSettings.cc
@@ -136,7 +136,7 @@ string YSettings::themeDir ()
     }
     else if ( _progDir.size() )
     {
-        //back compatibility if setProgSubDir is set to "/usr/share/YaST2"
+        // backwards compatibility if setProgSubDir is set to "/usr/share/YaST2"
         return _progDir + "/theme/current/wizard/";
     }
 
@@ -169,7 +169,7 @@ string YSettings::localeDir ()
     }
     else if ( _progDir.size() )
     {
-        //back compatibility if ProgDir is set to "/usr/share/YaST2"
+        // backwards compatibility if ProgDir is set to "/usr/share/YaST2"
         return _progDir + "/locale/";
     }
 

--- a/src/YSettings.cc
+++ b/src/YSettings.cc
@@ -73,7 +73,7 @@ void YSettings::setProgDir( string directory )
 
 string YSettings::progDir ()
 {
-    yuiDebug () << "progDir: \"" << _progDir << "\"" << endl;
+    // yuiDebug () << "progDir: \"" << _progDir << "\"" << endl;
 
     return _progDir;
 }

--- a/src/YSettings.h
+++ b/src/YSettings.h
@@ -44,11 +44,11 @@ class YUILoader;
 /**
  * Settings for libyui
  *
- * This singleton-object hold some presets for libyui.
+ * This singleton object hold some presets for libyui.
  **/
 class YSettings
 {
-friend YUILoader;
+    friend YUILoader;
 
 public:
     /**
@@ -58,11 +58,12 @@ public:
      * Once this is set, it can't be altered. If you do so although an
      * exception will be thrown.
      **/
-    static void setProgDir ( std::string directory );
+    static void setProgDir( std::string directory );
+
     /**
      * Returns the value of your program's subdir.
      **/
-    static std::string progDir ();
+    static std::string progDir();
 
     /**
      * This can be used to set a subdir ICONDIR,
@@ -71,11 +72,12 @@ public:
      * Once this is set, it can't be altered. If you do so although an
      * exception will be thrown.
      **/
-    static void setIconDir ( std::string directory );
+    static void setIconDir( std::string directory );
+
     /**
      * Returns the value of your program's icons subdir.
      **/
-    static std::string iconDir ();
+    static std::string iconDir();
 
     /**
      * This can be used to set a subdir THEMEDIR,
@@ -85,6 +87,7 @@ public:
      * exception will be thrown.
      **/
     static void setThemeDir ( std::string directory );
+
     /**
      * Returns the value of your program's theme subdir.
      **/
@@ -97,11 +100,12 @@ public:
      * Once this is set, it can't be altered. If you do so although an
      * exception will be thrown.
      **/
-    static void setLocaleDir ( std::string directory );
+    static void setLocaleDir( std::string directory );
+
     /**
      * Returns the value of your program's locale subdir.
      **/
-    static std::string localeDir ();
+    static std::string localeDir();
 
     /**
      * This can be used to set the loaded UI-backend.
@@ -109,13 +113,16 @@ public:
      * Once this is set, it can't be altered. If you do so although an
      * exception will be thrown.
      **/
-    static void loadedUI ( std::string ui );
+    static void loadedUI( std::string ui );
+
     /**
      * Returns the value of the loaded UI-backend.
      **/
-    static std::string loadedUI ();
+    static std::string loadedUI();
+
 
 protected:
+
     /**
      * This can be used to set the loaded UI-backend.
      *
@@ -125,15 +132,16 @@ protected:
     static void loadedUI ( std::string ui, bool force );
 
 private:
+
     static std::string _progDir;
     static std::string _iconDir;
     static std::string _themeDir;
     static std::string _localeDir;
     static std::string _loadedUI;
 
-    YSettings ();
-    YSettings ( const YSettings& );
-    ~YSettings ();
+    YSettings();
+    YSettings( const YSettings & );
+    ~YSettings();
 };
 
 #endif // YSettings_h

--- a/src/YSimpleInputField.h
+++ b/src/YSimpleInputField.h
@@ -87,7 +87,7 @@ public:
      * 'false' if that value requires special handling (not in error cases:
      * those are covered by exceptions).
      **/
-    virtual bool setProperty( const std::string & propertyName,
+    virtual bool setProperty( const std::string    & propertyName,
 			      const YPropertyValue & val );
 
     /**

--- a/src/YTable.cc
+++ b/src/YTable.cc
@@ -189,7 +189,7 @@ YTable::propertySet()
 	 * @property itemList	SelectedItems	All currently selected items
 	 * @property string	Cell		One cell (one column of one item)
 	 * @property integer	Cell		(ChangeWidget only) One cell as integer
-	 * @property `icon(...)	Cell		Icon for one one cell
+	 * @property `icon(...)	Cell		Icon for one cell
 	 * @property string	Item		Alias for Cell
 	 * @property string	Item		QueryWidget only: Return one complete item
 	 * @property string	IconPath	Base path for icons

--- a/src/YTable.h
+++ b/src/YTable.h
@@ -181,7 +181,7 @@ public:
      * 'false' if that value requires special handling (not in error cases:
      * those are covered by exceptions).
      **/
-    virtual bool setProperty( const std::string & propertyName,
+    virtual bool setProperty( const std::string    & propertyName,
 			      const YPropertyValue & val );
 
     /**

--- a/src/YTable.h
+++ b/src/YTable.h
@@ -52,6 +52,9 @@ class YTablePrivate;
  * (*) Not all UIs (in particular not text-based UIs) support displaying icons,
  * so an icon should never be an exclusive means to display any kind of
  * information.
+ *
+ * See also
+ * https://github.com/libyui/libyui-ncurses/blob/master/doc/nctable-and-nctree.md
  **/
 class YTable : public YSelectionWidget
 {

--- a/src/YTable.h
+++ b/src/YTable.h
@@ -38,7 +38,7 @@ class YTablePrivate;
  * Table: Selection list with multiple columns. The user can select exactly one
  * row (with all its columns) from that list. Each cell (each column within
  * each row) has a label text, an optional icon (*) and an optional sort-key
- * (used instead of the label text during sort).
+ * (used instead of the label text during sorting).
  *
  * This widget is similar to SelectionBox, but it has several columns for each
  * item (each row). If just one column is desired, consider using SelectionBox

--- a/src/YTableItem.cc
+++ b/src/YTableItem.cc
@@ -22,6 +22,9 @@
 
 /-*/
 
+#define YUILogComponent "ui"
+#include "YUILog.h"
+
 #include "YTableItem.h"
 #include "YUIException.h"
 
@@ -55,38 +58,44 @@ YTableItem::YTableItem( const string & label_0,
 			const string & label_9 )
     : YTreeItem( "" )
 {
-    std::vector<string> labels;
-    labels.reserve(10); // slight optimization
-    labels.push_back( label_0 );
-    labels.push_back( label_1 );
-    labels.push_back( label_2 );
-    labels.push_back( label_3 );
-    labels.push_back( label_4 );
-    labels.push_back( label_5 );
-    labels.push_back( label_6 );
-    labels.push_back( label_7 );
-    labels.push_back( label_8 );
-    labels.push_back( label_9 );
-
-    //
-    // Find the last non-empty label
-    //
-
-    unsigned lastLabel = labels.size() - 1;
-
-    while ( labels[ lastLabel ].empty() && --lastLabel > 0 )
-    {}
-
-    //
-    // Create cells
-    //
-
-    for ( unsigned i = 0; i <= lastLabel; ++i )
-    {
-	addCell( labels[i] );
-    }
+    addCells( label_0,
+              label_1,
+              label_2,
+              label_3,
+              label_4,
+              label_5,
+              label_6,
+              label_7,
+              label_8,
+              label_9 );
 }
 
+
+YTableItem::YTableItem( YTableItem *   parent,
+                        bool           isOpen,
+                        const string & label_0,
+			const string & label_1,
+			const string & label_2,
+			const string & label_3,
+			const string & label_4,
+			const string & label_5,
+			const string & label_6,
+			const string & label_7,
+			const string & label_8,
+			const string & label_9 )
+    : YTreeItem( parent, "", isOpen )
+{
+    addCells( label_0,
+              label_1,
+              label_2,
+              label_3,
+              label_4,
+              label_5,
+              label_6,
+              label_7,
+              label_8,
+              label_9 );
+}
 
 
 YTableItem::~YTableItem()
@@ -128,6 +137,52 @@ YTableItem::addCell( const string & label, const string & iconName, const string
     YUI_CHECK_NEW( cell );
 
     addCell( cell );
+}
+
+
+void
+YTableItem::addCells( const std::string & label_0,
+                      const std::string & label_1,
+                      const std::string & label_2,
+                      const std::string & label_3,
+                      const std::string & label_4,
+                      const std::string & label_5,
+                      const std::string & label_6,
+                      const std::string & label_7,
+                      const std::string & label_8,
+                      const std::string & label_9 )
+{
+    std::vector<string> labels;
+    labels.reserve(10); // slight optimization
+    labels.push_back( label_0 );
+    labels.push_back( label_1 );
+    labels.push_back( label_2 );
+    labels.push_back( label_3 );
+    labels.push_back( label_4 );
+    labels.push_back( label_5 );
+    labels.push_back( label_6 );
+    labels.push_back( label_7 );
+    labels.push_back( label_8 );
+    labels.push_back( label_9 );
+
+    //
+    // Find the last non-empty label
+    //
+
+    unsigned lastLabel = labels.size() - 1;
+
+    while ( labels[ lastLabel ].empty() && --lastLabel > 0 )
+    {}
+
+    //
+    // Create cells
+    //
+
+    for ( unsigned i = 0; i <= lastLabel; ++i )
+    {
+        yuiMilestone() << "Adding cell #" << i << ": " << labels[i] << endl;
+	addCell( labels[i] );
+    }
 }
 
 
@@ -173,9 +228,6 @@ YTableItem::hasIconName( int index ) const
 {
     return hasCell( index ) ? _cells[ index ]->hasIconName() : false;
 }
-
-
-
 
 
 void YTableCell::reparent( YTableItem * parent, int column )

--- a/src/YTableItem.cc
+++ b/src/YTableItem.cc
@@ -22,7 +22,8 @@
 
 /-*/
 
-#define MAX_DEBUG_LABEL_LEN	32
+#define MIN_DEBUG_LABEL_LEN	20
+#define MAX_DEBUG_LABEL_LEN	40
 
 
 #define YUILogComponent "ui"
@@ -239,7 +240,20 @@ YTableItem::debugLabel() const
     if ( _cells.empty() )
         return "[empty]";
 
-    return limitLength( label( 0 ), MAX_DEBUG_LABEL_LEN );
+    string txt;
+
+    for ( unsigned i=0; i < _cells.size(); ++i )
+    {
+        if ( ! txt.empty() )
+            txt += " | ";
+
+        txt += label( i );
+
+        if ( txt.size() > MIN_DEBUG_LABEL_LEN )
+            break;
+    }
+
+    return limitLength( txt, MAX_DEBUG_LABEL_LEN );
 }
 
 

--- a/src/YTableItem.cc
+++ b/src/YTableItem.cc
@@ -22,6 +22,9 @@
 
 /-*/
 
+#define MAX_DEBUG_LABEL_LEN	32
+
+
 #define YUILogComponent "ui"
 #include "YUILog.h"
 
@@ -230,6 +233,17 @@ YTableItem::hasIconName( int index ) const
 }
 
 
+string
+YTableItem::debugLabel() const
+{
+    if ( _cells.empty() )
+        return "[empty]";
+
+    return limitLength( label( 0 ), MAX_DEBUG_LABEL_LEN );
+}
+
+
+//----------------------------------------------------------------------
 
 
 void YTableCell::reparent( YTableItem * parent, int column )

--- a/src/YTableItem.cc
+++ b/src/YTableItem.cc
@@ -230,6 +230,8 @@ YTableItem::hasIconName( int index ) const
 }
 
 
+
+
 void YTableCell::reparent( YTableItem * parent, int column )
 {
     YUI_CHECK_PTR( parent );

--- a/src/YTableItem.cc
+++ b/src/YTableItem.cc
@@ -72,7 +72,6 @@ YTableItem::YTableItem( const string & label_0,
 
 
 YTableItem::YTableItem( YTableItem *   parent,
-                        bool           isOpen,
                         const string & label_0,
 			const string & label_1,
 			const string & label_2,
@@ -83,7 +82,7 @@ YTableItem::YTableItem( YTableItem *   parent,
 			const string & label_7,
 			const string & label_8,
 			const string & label_9 )
-    : YTreeItem( parent, "", isOpen )
+    : YTreeItem( parent, "" )
 {
     addCells( label_0,
               label_1,
@@ -131,7 +130,9 @@ YTableItem::addCell( YTableCell * cell )
 
 
 void
-YTableItem::addCell( const string & label, const string & iconName, const string & sortKey )
+YTableItem::addCell( const string & label,
+                     const string & iconName,
+                     const string & sortKey )
 {
     YTableCell * cell = new YTableCell( label, iconName, sortKey );
     YUI_CHECK_NEW( cell );

--- a/src/YTableItem.cc
+++ b/src/YTableItem.cc
@@ -29,7 +29,15 @@ using std::string;
 
 
 YTableItem::YTableItem()
-    : YItem( "" )
+    : YTreeItem( "" )
+{
+    // NOP
+}
+
+
+YTableItem::YTableItem( YTableItem * parent,
+                        bool         isOpen )
+    : YTreeItem( parent, "", isOpen )
 {
     // NOP
 }
@@ -45,7 +53,7 @@ YTableItem::YTableItem( const string & label_0,
 			const string & label_7,
 			const string & label_8,
 			const string & label_9 )
-    : YItem( "" )
+    : YTreeItem( "" )
 {
     std::vector<string> labels;
     labels.reserve(10); // slight optimization

--- a/src/YTableItem.cc
+++ b/src/YTableItem.cc
@@ -180,7 +180,6 @@ YTableItem::addCells( const std::string & label_0,
 
     for ( unsigned i = 0; i <= lastLabel; ++i )
     {
-        yuiMilestone() << "Adding cell #" << i << ": " << labels[i] << endl;
 	addCell( labels[i] );
     }
 }

--- a/src/YTableItem.h
+++ b/src/YTableItem.h
@@ -43,6 +43,7 @@ typedef YTableCellCollection::iterator		YTableCellIterator;
 typedef YTableCellCollection::const_iterator	YTableCellConstIterator;
 
 
+
 /**
  * Item class for YTable items. Each YTableItem corresponds to one row in a
  * YTable.
@@ -385,5 +386,4 @@ private:
 };
 
 
-
- #endif // YTableItem_h
+#endif // YTableItem_h

--- a/src/YTableItem.h
+++ b/src/YTableItem.h
@@ -123,6 +123,12 @@ public:
     virtual ~YTableItem();
 
     /**
+     * Returns a descriptive name of this widget class for logging,
+     * debugging etc.
+     **/
+    virtual const char * itemClass() const { return "YTableItem"; }
+
+    /**
      * Add a cell. This item will assume ownership over the cell and delete it
      * when appropriate (when the table is destroyed or when table items are
      * replaced), at which time the pointer will become invalid.
@@ -212,6 +218,12 @@ public:
      * Just for debugging.
      **/
     std::string label() const { return label(0); }
+
+    /**
+     * Return a descriptive label of this item instance for debugging.
+     * This might be truncated if the original label is too long.
+     **/
+    virtual std::string debugLabel() const;
 
 
 private:

--- a/src/YTableItem.h
+++ b/src/YTableItem.h
@@ -73,7 +73,7 @@ public:
                 bool         isOpen = false );
 
     /**
-     * Convenience constructor for (toplevel) table items without any icons.
+     * Convenience constructor for a (toplevel) table item without any icons.
      *
      * This will create up to 10 (0..9) cells. Empty cells for empty labels at
      * the end of the labels are not created, but empty cells in between are.
@@ -89,6 +89,22 @@ public:
      *     cell[4] ==> "five"
      **/
     YTableItem( const std::string & label_0,
+                const std::string & label_1 = std::string(),
+                const std::string & label_2 = std::string(),
+                const std::string & label_3 = std::string(),
+                const std::string & label_4 = std::string(),
+                const std::string & label_5 = std::string(),
+                const std::string & label_6 = std::string(),
+                const std::string & label_7 = std::string(),
+                const std::string & label_8 = std::string(),
+                const std::string & label_9 = std::string() );
+
+    /**
+     * Convenience constructor for a nested table item without any icons.
+     **/
+    YTableItem( YTableItem *        parent,
+                bool                isOpen,
+                const std::string & label_0,
                 const std::string & label_1 = std::string(),
                 const std::string & label_2 = std::string(),
                 const std::string & label_3 = std::string(),
@@ -118,12 +134,26 @@ public:
     void addCell( YTableCell * cell_disown );
 
     /**
-     * Create a new cell and add it (even if all 'label',
-     * 'iconName' and 'sortKey' are empty).
+     * Create a new cell and add it (even if all 'label', 'iconName' and
+     * 'sortKey' are empty).
      **/
     void addCell( const std::string & label,
                   const std::string & iconName = std::string(),
 		  const std::string & sortKey  = std::string() );
+
+    /**
+     * Add up to 10 cells without any icons.
+     **/
+    void addCells( const std::string & label_0,
+                   const std::string & label_1,
+                   const std::string & label_2 = std::string(),
+                   const std::string & label_3 = std::string(),
+                   const std::string & label_4 = std::string(),
+                   const std::string & label_5 = std::string(),
+                   const std::string & label_6 = std::string(),
+                   const std::string & label_7 = std::string(),
+                   const std::string & label_8 = std::string(),
+                   const std::string & label_9 = std::string() );
 
     /**
      * Delete all cells.

--- a/src/YTableItem.h
+++ b/src/YTableItem.h
@@ -103,7 +103,6 @@ public:
      * Convenience constructor for a nested table item without any icons.
      **/
     YTableItem( YTableItem *        parent,
-                bool                isOpen,
                 const std::string & label_0,
                 const std::string & label_1 = std::string(),
                 const std::string & label_2 = std::string(),
@@ -177,7 +176,7 @@ public:
      * or 0 if there is none.
      **/
     const YTableCell * cell( int index ) const;
-    YTableCell * cell( int index );
+    YTableCell *       cell( int index );
 
     /**
      * Return the number of cells this item has.

--- a/src/YTableItem.h
+++ b/src/YTableItem.h
@@ -25,7 +25,7 @@
 #ifndef YTableItem_h
 #define YTableItem_h
 
-#include "YItem.h"
+#include "YTreeItem.h"
 
 
 class YTableCell;
@@ -35,8 +35,10 @@ class YTableCell;
 
 //! Collection of pointers to YTableCell
 typedef std::vector<YTableCell *>		YTableCellCollection;
+
 //! Mutable iterator over @ref YTableCellCollection
 typedef YTableCellCollection::iterator		YTableCellIterator;
+
 //! Const   iterator over @ref YTableCellCollection
 typedef YTableCellCollection::const_iterator	YTableCellConstIterator;
 
@@ -55,7 +57,7 @@ typedef YTableCellCollection::const_iterator	YTableCellConstIterator;
  * calling certain methods of the YTable widget. See the YTable reference for
  * details.
  **/
-class YTableItem: public YItem
+class YTableItem: public YTreeItem
 {
 public:
 
@@ -65,7 +67,13 @@ public:
     YTableItem();
 
     /**
-     * Convenience constructor for table items without any icons.
+     * Constructor for a nested table item, i.e. one with a parent item.
+     **/
+    YTableItem( YTableItem * parent,
+                bool         isOpen = false );
+
+    /**
+     * Convenience constructor for (toplevel) table items without any icons.
      *
      * This will create up to 10 (0..9) cells. Empty cells for empty labels at
      * the end of the labels are not created, but empty cells in between are.
@@ -113,8 +121,9 @@ public:
      * Create a new cell and add it (even if all 'label',
      * 'iconName' and 'sortKey' are empty).
      **/
-    void addCell( const std::string & label, const std::string & iconName = std::string(),
-		  const std::string & sortKey = std::string() );
+    void addCell( const std::string & label,
+                  const std::string & iconName = std::string(),
+		  const std::string & sortKey  = std::string() );
 
     /**
      * Delete all cells.
@@ -173,6 +182,7 @@ public:
      * Just for debugging.
      **/
     std::string label() const { return label(0); }
+
 
 private:
 

--- a/src/YTimeField.h
+++ b/src/YTimeField.h
@@ -41,12 +41,14 @@ class YTimeFieldPrivate;
 class YTimeField : public YSimpleInputField
 {
 protected:
+
     /**
      * Constructor.
      **/
     YTimeField( YWidget * parent, const std::string & label );
 
 public:
+
     /**
      * Destructor.
      **/

--- a/src/YTimezoneSelector.h
+++ b/src/YTimezoneSelector.h
@@ -46,9 +46,9 @@ protected:
      *
      * The widget is only displaying timezones/cities in that map
      **/
-    YTimezoneSelector( YWidget *parent,
-                       const std::string &pixmap,
-		       const std::map<std::string, std::string> &timezones );
+    YTimezoneSelector( YWidget * parent,
+                       const std::string & pixmap,
+		       const std::map<std::string, std::string> & timezones );
 
 public:
     /**
@@ -72,7 +72,7 @@ public:
      * 'false' if that value requires special handling (not in error cases:
      * those are covered by exceptions).
      **/
-    virtual bool setProperty( const std::string & propertyName,
+    virtual bool setProperty( const std::string    & propertyName,
 			      const YPropertyValue & val );
 
     /**
@@ -99,7 +99,7 @@ public:
     /**
      * subclasses have to implement this to set value
      */
-    virtual void setCurrentZone( const std::string &zone, bool zoom ) = 0;
+    virtual void setCurrentZone( const std::string & zone, bool zoom ) = 0;
 
 private:
     ImplPtr<YTimezoneSelectorPrivate> priv;

--- a/src/YTree.cc
+++ b/src/YTree.cc
@@ -32,6 +32,7 @@
 #include "YTreeItem.h"
 
 using std::string;
+using std::vector;
 
 
 struct YTreePrivate
@@ -44,7 +45,10 @@ struct YTreePrivate
 };
 
 
-YTree::YTree( YWidget * parent, const string & label, bool multiSelection, bool recursiveSelection )
+YTree::YTree( YWidget *      parent,
+              const string & label,
+              bool           multiSelection,
+              bool           recursiveSelection )
     : YSelectionWidget( parent, label,
 			! multiSelection,
 			recursiveSelection )
@@ -172,37 +176,41 @@ YTree::hasMultiSelection() const
 
 
 YTreeItem *
-YTree::findItem( std::vector<std::string> & path ) const
+YTree::findItem( vector<string> & path ) const
 {
-    return findItem( path.begin(), path.end(), itemsBegin(), itemsEnd());
+    return findItem( path.begin(), path.end(),
+                     itemsBegin(), itemsEnd() );
 }
 
 
 YTreeItem *
-YTree::findItem( std::vector<std::string>::iterator path_begin,
-                       std::vector<std::string>::iterator path_end,
-                       YItemConstIterator begin,
-                       YItemConstIterator end ) const
+YTree::findItem( vector<string>::iterator path_begin,
+                 vector<string>::iterator path_end,
+                 YItemConstIterator       begin,
+                 YItemConstIterator       end ) const
 {
     for ( YItemConstIterator it = begin; it != end; ++it )
     {
-        YTreeItem * item = dynamic_cast<YTreeItem *>(*it);
-        // Test that dynamic_cast didn't fail
-        if (!item)
-            return nullptr;
+        YTreeItem * item = dynamic_cast<YTreeItem *>( *it );
+
+        if ( ! item )
+            return 0;
 
         if ( item->label() == *path_begin )
         {
-            if ( std::next(path_begin) == path_end )
+            if ( std::next( path_begin ) == path_end )
             {
                 return item;
             }
-            // Look in child nodes and return if found one
-            YTreeItem * result = findItem( ++path_begin, path_end, item->childrenBegin(), item->childrenEnd() );
+
+            // Recursively search child items
+            YTreeItem * result = findItem( ++path_begin, path_end,
+                                           item->childrenBegin(), item->childrenEnd() );
+
             if ( result )
                 return result;
         }
     }
 
-    return nullptr;
+    return 0;
 }

--- a/src/YTree.cc
+++ b/src/YTree.cc
@@ -176,7 +176,7 @@ YTree::hasMultiSelection() const
 
 
 YTreeItem *
-YTree::findItem( vector<string> & path ) const
+YTree::findItem( const vector<string> & path ) const
 {
     return findItem( path.begin(), path.end(),
                      itemsBegin(), itemsEnd() );
@@ -184,10 +184,10 @@ YTree::findItem( vector<string> & path ) const
 
 
 YTreeItem *
-YTree::findItem( vector<string>::iterator path_begin,
-                 vector<string>::iterator path_end,
-                 YItemConstIterator       begin,
-                 YItemConstIterator       end ) const
+YTree::findItem( vector<string>::const_iterator path_begin,
+                 vector<string>::const_iterator path_end,
+                 YItemConstIterator             begin,
+                 YItemConstIterator             end ) const
 {
     for ( YItemConstIterator it = begin; it != end; ++it )
     {

--- a/src/YTree.cc
+++ b/src/YTree.cc
@@ -191,7 +191,7 @@ YTree::findItem( std::vector<std::string>::iterator path_begin,
         if (!item)
             return nullptr;
 
-        if( item->label() == *path_begin )
+        if ( item->label() == *path_begin )
         {
             if ( std::next(path_begin) == path_end )
             {

--- a/src/YTree.h
+++ b/src/YTree.h
@@ -191,7 +191,7 @@ public:
      * 'path' is a vector of strings with the path components, e.g.
      * ["usr", "share", "doc", "packages"].
      **/
-    YTreeItem * findItem( std::vector<std::string> & path ) const;
+    YTreeItem * findItem( const std::vector<std::string> & path ) const;
 
 
 protected:
@@ -203,10 +203,10 @@ protected:
      *
      * This is a helper function for findItem( std::vector<std::string> & ).
      */
-    YTreeItem * findItem( std::vector<std::string>::iterator path_begin,
-                          std::vector<std::string>::iterator path_end,
-                          YItemConstIterator                 begin,
-                          YItemConstIterator                 end ) const;
+    YTreeItem * findItem( std::vector<std::string>::const_iterator path_begin,
+                          std::vector<std::string>::const_iterator path_end,
+                          YItemConstIterator                       begin,
+                          YItemConstIterator                       end ) const;
 
 private:
 

--- a/src/YTree.h
+++ b/src/YTree.h
@@ -50,9 +50,10 @@ class YTreePrivate;
 
  * 'multiSelection' indicates whether or not the user can select multiple
  * items at the same time. This can only be set in the constructor.
+ *
+ * See also
+ * https://github.com/libyui/libyui-ncurses/blob/master/doc/nctable-and-nctree.md
  **/
-
-
 class YTree : public YSelectionWidget
 {
 protected:

--- a/src/YTree.h
+++ b/src/YTree.h
@@ -56,21 +56,17 @@ class YTreePrivate;
 class YTree : public YSelectionWidget
 {
 protected:
+
     /**
      * Constructor.
      **/
-    YTree( YWidget * parent, const std::string & label, bool multiSelection, bool recursiveSelection);
+    YTree( YWidget *           parent,
+           const std::string & label,
+           bool                multiSelection,
+           bool                recursiveSelection);
 
-    /**
-     * Recursively looks for the first item in the tree of the menu items
-     * using depth first search.
-     * Return nullptr if item which matches full path is not found.
-     */
-    YTreeItem * findItem( std::vector<std::string>::iterator path_begin,
-                          std::vector<std::string>::iterator path_end,
-                          YItemConstIterator                 begin,
-                          YItemConstIterator                 end ) const;
 public:
+
     /**
      * Destructor.
      **/
@@ -182,19 +178,35 @@ public:
     virtual YTreeItem * currentItem() = 0;
 
     /**
-     * Return item in the tree which matches path of labels or nullptr in case no
-     * item with such label was found.
-     * Accepts vector of strings which denote path to the node.
-     **/
-    YTreeItem * findItem( std::vector<std::string> & path ) const;
-
-    /**
-    * Activate the item selected in the tree. Can be used in tests to simulate user input.
+    * Activate the item selected in the tree. This can be used in automated
+    * tests to simulate user input.
     *
     * Derived classes are required to implement this.
     **/
     virtual void activate() = 0;
 
+    /**
+     * Return the item in the tree that matches path of labels or 0 if not found.
+     *
+     * 'path' is a vector of strings with the path components, e.g.
+     * ["usr", "share", "doc", "packages"].
+     **/
+    YTreeItem * findItem( std::vector<std::string> & path ) const;
+
+
+protected:
+
+    /**
+     * Recursively search the items between item iterators 'begin' and 'end'
+     * for a path specified in a string vector between 'path_begin' and
+     * 'path_end'. Return that item or 0 if not found.
+     *
+     * This is a helper function for findItem( std::vector<std::string> & ).
+     */
+    YTreeItem * findItem( std::vector<std::string>::iterator path_begin,
+                          std::vector<std::string>::iterator path_end,
+                          YItemConstIterator                 begin,
+                          YItemConstIterator                 end ) const;
 
 private:
 

--- a/src/YTree.h
+++ b/src/YTree.h
@@ -68,8 +68,8 @@ protected:
      */
     YTreeItem * findItem( std::vector<std::string>::iterator path_begin,
                           std::vector<std::string>::iterator path_end,
-                          YItemConstIterator begin,
-                          YItemConstIterator end ) const;
+                          YItemConstIterator                 begin,
+                          YItemConstIterator                 end ) const;
 public:
     /**
      * Destructor.
@@ -139,7 +139,7 @@ public:
      * 'false' if that value requires special handling (not in error cases:
      * those are covered by exceptions).
      **/
-    virtual bool setProperty( const std::string & propertyName,
+    virtual bool setProperty( const std::string    & propertyName,
 			      const YPropertyValue & val );
 
     /**

--- a/src/YTreeItem.h
+++ b/src/YTreeItem.h
@@ -117,7 +117,8 @@ public:
     /**
      * Change the 'isOpen' flag.
      **/
-    void setOpen( bool open );
+    void setOpen( bool open = true );
+    void setClosed() { setOpen( false ); }
 
     /**
      * Returns this item's parent item or 0 if it is a toplevel item.

--- a/src/YTreeItem.h
+++ b/src/YTreeItem.h
@@ -69,6 +69,12 @@ public:
     virtual ~YTreeItem();
 
     /**
+     * Returns a descriptive name of this widget class for logging,
+     * debugging etc.
+     **/
+    virtual const char * itemClass() const { return "YTreeItem"; }
+
+    /**
      * Return 'true' if this item has any child items.
      *
      * Reimplemented from YItem.

--- a/src/YUILoader.cc
+++ b/src/YUILoader.cc
@@ -57,9 +57,9 @@ void YUILoader::loadUI( bool withThreads )
 
     string wantedGUI;
 
-    yuiMilestone () << "DISPLAY: \""              << envDisplay << "\"" << endl;
-    yuiMilestone () << "XDG_CURRENT_DESKTOP: \""  << envDesktop << "\"" << endl;
-    yuiMilestone () << "YUI_PREFERED_BACKEND: \"" << envPreset  << "\"" << endl;
+    yuiMilestone() << "DISPLAY: \""              << envDisplay << "\"" << endl;
+    yuiMilestone() << "XDG_CURRENT_DESKTOP: \""  << envDesktop << "\"" << endl;
+    yuiMilestone() << "YUI_PREFERED_BACKEND: \"" << envPreset  << "\"" << endl;
 
     // Taken from: https://specifications.freedesktop.org/menu-spec/menu-spec-1.1.html#onlyshowin-registry
     isGtk = ( ( strstr( envDesktop, "Cinnamon" ) != NULL ) || isGtk );

--- a/src/YUILoader.h
+++ b/src/YUILoader.h
@@ -34,15 +34,17 @@
 
 
 
-#define YUIPlugin_Qt		"qt"
-#define YUIPlugin_NCurses	"ncurses"
-#define YUIPlugin_Gtk		"gtk"
-#define YUIPlugin_RestAPI       "rest-api"
+#define YUIPlugin_Qt                    "qt"
+#define YUIPlugin_NCurses               "ncurses"
+#define YUIPlugin_Gtk                   "gtk"
+
+#define YUIPlugin_RestAPI               "rest-api"
 #define YUIPlugin_Ncurses_RestAPI       "ncurses-rest-api"
-#define YUIPlugin_Qt_RestAPI       "qt-rest-api"
+#define YUIPlugin_Qt_RestAPI            "qt-rest-api"
 
 /**
- * Class to load one of the concrete UI plug-ins: Qt, NCurses, Gtk.
+ * Class to load one of the concrete UI plug-ins: Qt, NCurses, Gtk;
+ * or one of the corresponding REST APIs used for automated testing.
  **/
 class YUILoader
 {
@@ -112,6 +114,9 @@ public:
      **/
     static void loadPlugin( const std::string & name, bool withThreads = false );
 
+    /**
+     * Check if a plug-in exists.
+     **/
     static bool pluginExists( const std::string & pluginBaseName );
 
     /**
@@ -129,7 +134,8 @@ public:
      *          (e.g. default YExternalWidgets* createExternalWidgets(const char *)
      *          see createEWFunction_t definition)
      **/
-    static void loadExternalWidgets( const std::string & name, const std::string & symbol="_Z21createExternalWidgetsPKc" );
+    static void loadExternalWidgets( const std::string & name,
+                                     const std::string & symbol = "_Z21createExternalWidgetsPKc" );
 
 private:
     YUILoader()  {}
@@ -141,11 +147,14 @@ private:
      * 'name'        is the original plugin name (e.g. the one passed to loadExternalWidgets)
      * 'plugin_name' is the graphical plugin specialization name (e.g. 'name'-[gtk|ncurses|qt])
      * 'symbol'      is the function symbol to be loaded and executed (e.g. the one passed loadExternalWidgets)
+     *
      * This might throw exceptions:
      * YUIPluginException if the plugin has not been loaded
      * specific exception can be thrown by funtion invoked (param symbol)
      **/
-    static void loadExternalWidgetsPlugin( const std::string& name, const std::string& plugin_name, const std::string& symbol );
+    static void loadExternalWidgetsPlugin( const std::string & name,
+                                           const std::string & plugin_name,
+                                           const std::string & symbol );
 };
 
 
@@ -170,12 +179,13 @@ typedef YUI * (*createUIFunction_t)( bool );
 typedef YExternalWidgets * (*createEWFunction_t)( const char * );
 
 /**
- * For the integration testing YUI has separate framework which allows to have
- * control over UI using REST API. Server has to be started after testing framework
- * plugin is loaded, which is done by the method which creates server instance.
- * Not to have additional definition imports, we define it as void here.
- * In the framework calls it can be used to
-**/
+ * For integration testing, YUI has separate framework which allows to have
+ * control over UI using REST API. The server has to be started after testing
+ * if the framework plugin is loaded, which is done by the method which creates
+ * the server instance.  To avoid having to include additional type, we define
+ * it as 'void' here.
+ **/
 typedef void (*getServerFunction_t)();
+
 
 #endif // YUILoader_h

--- a/src/YUISymbols.h
+++ b/src/YUISymbols.h
@@ -349,6 +349,8 @@
 #define YUISymbol_topMargin			"topMargin"
 #define YUISymbol_bottomMargin			"bottomMargin"
 #define YUISymbol_BackgroundPixmap		"BackgroundPixmap"
+#define YUISymbol_open                          "open"
+#define YUISymbol_closed                        "closed"
 
 #define YUISymbol_Left				"Left"
 #define YUISymbol_Right				"Right"

--- a/src/YWidget.h
+++ b/src/YWidget.h
@@ -149,7 +149,7 @@ public:
      * 'false' if that value requires special handling (not in error cases:
      * those are covered by exceptions).
      **/
-    virtual bool setProperty( const std::string & propertyName,
+    virtual bool setProperty( const std::string    & propertyName,
 			      const YPropertyValue & val );
 
     /**

--- a/src/YWidgetFactory.h
+++ b/src/YWidgetFactory.h
@@ -110,7 +110,7 @@ public:
     virtual YComboBox *		createComboBox		( YWidget * parent, const std::string & label, bool editable	 = false )	= 0;
     virtual YSelectionBox *	createSelectionBox	( YWidget * parent, const std::string & label )					= 0;
     virtual YTree *		createTree		( YWidget * parent, const std::string & label, bool multiselection = false, bool recursiveselection = false ) = 0;
-    virtual YTable *		createTable		( YWidget * parent, YTableHeader * header_disown,     bool multiSelection = false )	= 0;
+    virtual YTable *		createTable		( YWidget * parent, YTableHeader * header_disown, bool multiSelection = false )	= 0;
     virtual YProgressBar *	createProgressBar	( YWidget * parent, const std::string & label, int  maxValue	   = 100   )	= 0;
     virtual YRichText *		createRichText		( YWidget * parent, const std::string & text = std::string(), bool plainTextMode = false )	= 0;
     virtual YBusyIndicator *	createBusyIndicator	( YWidget * parent, const std::string & label, int timeout = 1000 )		= 0;

--- a/src/YWidget_OptimizeChanges.h
+++ b/src/YWidget_OptimizeChanges.h
@@ -46,6 +46,7 @@ public:
     public:
 	OptimizeChanges( YWidget & w ) : yw(w)	{ yw.startMultipleChanges(); }
 	~OptimizeChanges()			{ yw.doneMultipleChanges();  }
+
     private:
 	OptimizeChanges( const OptimizeChanges & ); // no copy
 	void operator=( const OptimizeChanges & );  // no assign


### PR DESCRIPTION
## Trello

https://trello.com/c/dC5eSlNw/1957-8-nested-tables-widget

**This is the libyui part.**

## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1176402

## Problem

In certain situations we are displaying a hierarchy in a table: We have items that really have a tree structure, yet we need multiple columns to display all the information a user needs. The partitioner is such an example.

![storage-flat](https://user-images.githubusercontent.com/11538225/92713899-cb80a280-f35b-11ea-825a-6a5ebdd35dff.png)

_Simplified from a UI example; this is not the real partitioner, but it displays very similar contents_

The hierarchy is not clear from this. A user needs to have some context information like knowing how Linux device names are structured to make sense of the hierarchy: He needs to know that /dev/sda is a disk while /dev/sda1 is a partition on that disk.

This display is unwieldy already with the 3 disks displayed here (this is a real-life setup from my home PC). This already does not give a good overview. There is also no way to collapse tree branches that are irrelevant to the user right now: Knowing that /dev/sdb is an old rotating disk and the relevant data are now really on the /dev/sdc SSD, a user still cannot get all the partitions on /dev/sdb out of the way.

## Solution

Extend the concept to display the tree hierarchy in a table. A YItem can already have child items (which again can have child items, each of which can again have child items etc.). This is used in the Tree widget, but with only one column. We need to combine the concepts of the Tree and the Table widgets.

## Qt UI

Qt provides the QTreeWidget which is actually what we are already using for our YQTable widget; we are just not making use of the tree part.

![storage-nested-2](https://user-images.githubusercontent.com/11538225/92714683-cd973100-f35c-11ea-9d07-762364f4a92b.png)

_Tree-nested-items.rb UI example from yast-ycp-ui-bindings/examples, all items expanded_


![storage-nested-1](https://user-images.githubusercontent.com/11538225/92714670-c96b1380-f35c-11ea-815f-6be35416d15b.png)


_Tree-nested-items.rb UI example from yast-ycp-ui-bindings/examples, branch /dev/sdb collapsed_


## NCurses UI

In the NCurses UI, we have no such luxury. But the NCTree widget and the NCTable widget are closely related: They use an NCTreePad and an NCTablePad, respectively, that had a lot of common code ("_inheritance by copy & paste_").

See NCurses-UI PR for more details: https://github.com/libyui/libyui-ncurses/pull/103

![nc-storage-nested-1](https://user-images.githubusercontent.com/11538225/93923606-e667f500-fd13-11ea-9b7a-52b244460015.png)

![nc-storage-nested-2](https://user-images.githubusercontent.com/11538225/93923617-ea941280-fd13-11ea-8fd0-00a089bb7f51.png)



## New UI Syntax

```Ruby
      Table(Id(:mytable),
        Header("Device", "Size", "Type", "Mount Point"),
        [
          Item(Id(:sda), "/dev/sda", "931.5G", sda_items, :open),
          Item(Id(:sdb), "/dev/sdb", "931.5G", sdb_items, :closed),
          Item(Id(:sdc), "/dev/sdc", "232.9G", sdc_items, :open)
        ]
      )
    ...
    ...
    def sda_items
      [
        Item(Id(:sda1), "/dev/sda1",  "97.7G", "ntfs", "/win/boot" ),
        Item(Id(:sda2), "/dev/sda2", "833.9G", "ntfs", "/win/app"  )
      ]
    end
```

`:open` and `:closed` are special symbols to make a clear difference between an item's boolean _selected_ status (which of course is still there) and the branch open/closed status.



### Full UI Example (Ruby):

See yast-ycp-ui-bindings/examples/Table-nested-items.rb ([in PR][], [in master][]): (https://github.com/yast/yast-ycp-ui-bindings/pull/55)

[in pr]: https://github.com/yast/yast-ycp-ui-bindings/pull/55/files#diff-80fe1f01713c9d6e1c5acd90331ff79a
[in master]: https://github.com/yast/yast-ycp-ui-bindings/blob/master/examples/Table-nested-items.rb

(Click the arrow to open)
<details>

```ruby
# encoding: utf-8

# Example for table with nested items

module Yast
  class TableNestedItems < Client
    Yast.import "UI"

    def main
      UI.OpenDialog(main_dialog)
      handle_events
      UI.CloseDialog
    end

    def main_dialog
      MinSize(
        74, 17,
        MarginBox(
          1, 0.4,
          VBox(
            Left(
              Heading("Storage Overview")
            ),
            VSpacing(0.2),
            table,
            VSpacing(0.2),
            Left(Label("Selected:")),
            Label(Id(:selected), Opt(:outputField, :hstretch), ""),
            VSpacing(0.5),
            Right(
              PushButton(Id(:close), "&Close")
            )
          )
        )
      )
    end

    def table
      Table(
        Id(:table),
        Opt(:notify, :immediate),
        Header("Device", "Size", "Type", "Mount Point"),
        disk_items
      )
    end

    def disk_items
      [
        Item(Id(:sda), "/dev/sda", "931.5G", sda_items, :open),
        Item(Id(:sdb), "/dev/sdb", "931.5G", sdb_items, :closed),
        Item(Id(:sdc), "/dev/sdc", "232.9G", sdc_items, :open)
      ]
    end

    def sda_items
      [
        Item(Id(:sda1), "/dev/sda1",  "97.7G", "ntfs", "/win/boot" ),
        Item(Id(:sda2), "/dev/sda2", "833.9G", "ntfs", "/win/app"  )
      ]
    end

    def sdb_items
      [
        Item(Id(:sdb1), "/dev/sdb1",   "2.0G", "swap" ),
        Item(Id(:sdb2), "/dev/sdb2",  "29.4G", "ext4", "/hd-root-leap-42"   ),
        Item(Id(:sdb3), "/dev/sdb3",  "29.4G", "ext4", "/hd-root-leap-15-0" ),
        Item(Id(:sdb4), "/dev/sdb4", "855.8G", "xfs",  "/work" )
      ]
    end

    def sdc_items
      [
        Item(Id(:sdc1), "/dev/sdc1",   "2.0G", "swap", "[swap]" ),
        Item(Id(:sdc2), "/dev/sdc2",  "29.4G", "ext4", "/ssd-root-leap-15-1" ),
        Item(Id(:sdc3), "/dev/sdc3",  "29.4G", "ext4", "/" ),
        Item(Id(:sdc4), "/dev/sdc4", "167.2G", "ext4", "/ssd-work" )
      ]
    end

    def handle_events
      while true
        id = UI.UserInput
        case id

        when :close, :cancel # :cancel is WM_CLOSE
          break # leave event loop
        when :table
          update_selected(current_table_item)
        end
        id
      end
    end

    def current_table_item
      UI.QueryWidget(Id(:table), :CurrentItem)
    end

    def update_selected(id)
      id ||= "<nil>"
      UI.ChangeWidget(Id(:selected), :Value, id.to_s)
    end
  end
end

Yast::TableNestedItems.new.main
```

</details>

## New Docs

New document:

https://github.com/shundhammer/libyui-ncurses/blob/huha-tree-table-01/doc/nctable-and-nctree.md

![scary-nc-01](https://user-images.githubusercontent.com/11538225/93946502-bc292e00-fd39-11ea-9320-37527f90cb5a.png)

![scary-nc-02](https://user-images.githubusercontent.com/11538225/93946508-bf241e80-fd39-11ea-92fb-662eeb8fdc4f.png)



## Included here: ~~Ivan's PR~~

~~This PR also includes Ivan's work for this sprint about multiple keyboard shortcuts for selection widgets (MenuBar, ItemSelector) to avoid one round of PRs just for bumping the SO version of libyui. Ivan's PRs are already reviewed; they were merged to branch sprint-108 which was merged to this branch.~~

This PR will be merged into *sprint-108* branch, which already includes several new features (e.g., https://github.com/libyui/libyui/pull/170) that also require to bump the SO version of libyui.  Then, *sprint-108* will be merged into master.


## Releated PRs

- Qt UI: https://github.com/libyui/libyui-qt/pull/132
- NCurses UI: https://github.com/libyui/libyui-ncurses/pull/103
- NCurses Pkg: https://github.com/libyui/libyui-ncurses-pkg/pull/44
- UI Interpreter: https://github.com/yast/yast-ycp-ui-bindings/pull/55

### libyui SO Version Bump PRs