### PR TITLE
Allow to show or hide menu items

### DIFF
--- a/examples/MenuBar1.cc
+++ b/examples/MenuBar1.cc
@@ -46,6 +46,7 @@ YDialog	    * dialog		= 0;
 YMenuBar    * menuBar		= 0;
 YLabel	    * lastEventLabel	= 0;
 YCheckBox   * readOnlyCheckBox	= 0;
+YCheckBox   * visibleCheckBox	= 0;
 YPushButton * closeButton	= 0;
 
 
@@ -115,7 +116,6 @@ int main( int argc, char **argv )
     YUILog::enableDebugLogging();
 
     createWidgets();
-    updateActions();
     handleEvents();
 
     dialog->destroy();
@@ -151,7 +151,12 @@ void createWidgets()
     fac->createVSpacing( vbox2, 2 );
     readOnlyCheckBox = fac->createCheckBox( vbox2, "Read &Only", true );
     readOnlyCheckBox->setNotify( true );
+
     fac->createVSpacing( vbox2, 0.2 );
+    visibleCheckBox = fac->createCheckBox( vbox2, "&Visible", true );
+    visibleCheckBox->setNotify( true );
+
+    fac->createVSpacing( vbox2, 1 );
     closeButton = fac->createPushButton( vbox2, "&Close" );
 }
 
@@ -203,6 +208,9 @@ void handleEvents()
 {
     yuiMilestone() << endl;
 
+    dialog->open();
+    updateActions();
+
     while ( true )
     {
 	YEvent * event = dialog->waitForEvent();
@@ -230,6 +238,9 @@ void handleEvents()
 	    if ( event->widget() == readOnlyCheckBox )
 		updateActions();
 
+	    if ( event->widget() == visibleCheckBox )
+		updateActions();
+
 	    if ( event->widget() == closeButton )
 		break;
 	}
@@ -252,8 +263,9 @@ void showEvent( YMenuEvent * event )
 
 
 /**
- * Update the available menu actions: Enable or disable some of them according
- * to the current status of the "Read Only" check box.
+ * Update the available menu actions:
+ *   * Enable or disable some of them according to the current status of the "Read Only" check box.
+ *   * Show or hide some of them according to the current status of the "Visible" check box.
  **/
 void updateActions()
 {
@@ -262,4 +274,9 @@ void updateActions()
     menuBar->setItemEnabled( actionSave,  ! readOnly );
     menuBar->setItemEnabled( actionCut,	  ! readOnly );
     menuBar->setItemEnabled( actionPaste, ! readOnly );
+
+    bool visible = visibleCheckBox->isChecked();
+
+    menuBar->setItemVisible( contentsMenu, visible );
+    menuBar->setItemVisible( actionOpen, visible );
 }

--- a/src/YMenuItem.h
+++ b/src/YMenuItem.h
@@ -50,6 +50,7 @@ public:
 	       const std::string & 	iconName = "" )
 	: YTreeItem( label, iconName )
         , _enabled( true )
+	, _visible( true )
         , _uiItem( 0 )
 	{}
 
@@ -67,6 +68,7 @@ public:
 	       const std::string & 	iconName = "" )
 	: YTreeItem( parent, label, iconName )
         , _enabled( true )
+	, _visible( true )
         , _uiItem( 0 )
 	{}
 
@@ -132,6 +134,20 @@ public:
     void setEnabled( bool enabled = true ) { _enabled = enabled; }
 
     /**
+     * Return 'true' if this item is visible (which is the default).
+     **/
+    bool isVisible() const { return _visible; }
+
+    /**
+     * Show or hide this item.
+     *
+     * Applications should use YMenuWidget::setItemVisible() instead because
+     * that will also notify the widget so it can update the item's visual
+     * representation.
+     **/
+    void setVisible( bool visible = true ) { _visible = visible; }
+
+    /**
      * Return the UI counterpart of this item (if the UI set any).
      **/
     void * uiItem() const { return _uiItem; }
@@ -154,7 +170,8 @@ private:
 
     // Data members
 
-    bool   _enabled;
+    bool _enabled;
+    bool _visible;
     void * _uiItem;
 };
 

--- a/src/YMenuWidget.cc
+++ b/src/YMenuWidget.cc
@@ -113,6 +113,14 @@ YMenuWidget::setItemEnabled( YMenuItem * item, bool enabled )
 }
 
 
+void
+YMenuWidget::setItemVisible( YMenuItem * item, bool visible )
+{
+    if ( item )
+        item->setVisible( visible );
+}
+
+
 YMenuItem *
 YMenuWidget::findMenuItem( int index )
 {

--- a/src/YMenuWidget.h
+++ b/src/YMenuWidget.h
@@ -125,6 +125,16 @@ public:
     virtual void setItemEnabled( YMenuItem * item, bool enabled );
 
     /**
+     * Show or hide an item. This default implementation only updates the
+     * item's 'visible' field.
+     *
+     * Derived classes should overwrite this method and either update the
+     * item's 'visible' field in their implementation or call this default
+     * implementation.
+     **/
+    virtual void setItemVisible( YMenuItem * item, bool visible );
+
+    /**
      * Support for the Rest API for UI testing:
      *
      * Return the item in the tree which matches a path of labels. This


### PR DESCRIPTION
Note: This PR is going to be merged into *sprint-108* branch instead of master. There are some WIP features (i.e., nesting tables) and they all will be merged together into master to bump so versions only once.

## Problem

A new *YMenuBar* was added to *libyui*, but it lacks of the capability to show/hide items. Although such feature is not used by YaST at all, it is still useful for some third-party users of the library (i.e., [libyui-mga](https://github.com/manatools/libyui-mga)).

* PBI: https://trello.com/c/U20esvtq/2041-3-menu-bar-api-call-to-hide-show-entries.
* Menu bar: https://github.com/libyui/libyui/pull/169.

## Solution

Extend public API of *YMenuBar* to allow to indicate whether an item is visible or not. Note that it is possible to hide both: top level menus and also menu items.

See *examples/MenuBar1.cc* for an usage example.

* https://github.com/libyui/libyui-qt/pull/134

#### Changes

The *sprint-108* branch is accumulating several new features. The plan is to merge them all into master and bump the so versions only once. At that time, we will provide an entry in the *changes* file. Here is a proposal for that changes entry:

~~~
* Resolve hotkeys conflicts for widgets with multiple hotkeys
  (related to bsc#1175489).
* Allow to show/hide menus and menu items (related to
  manatools/libyui-mga#1).
* Allow nested items in tables (bsc#1176402).
~~~
