### PR TITLE
Fixed warnings

### DIFF
--- a/libyui-bindings/swig/ruby/examples/combo_box1.rb
+++ b/libyui-bindings/swig/ruby/examples/combo_box1.rb
@@ -48,8 +48,8 @@ require 'yui'
 
 	    valueField.set_value( "???" )
 
-	    if ( event.widget == closeButton )
-		break # leave event loop
+			# leave event loop
+	    break if ( event.widget == closeButton )
 
 	    if ( event.widget == valueButton || event.widget == comboBox )	# comboBox will only send events with setNotify()
 		# Get the current value of the ComboBox and display it in valueField.
@@ -99,4 +99,3 @@ require 'yui'
     #
 
     dialog.destroy
-end

--- a/libyui-bindings/swig/ruby/examples/hello_world.rb
+++ b/libyui-bindings/swig/ruby/examples/hello_world.rb
@@ -16,7 +16,6 @@ class LoadTest < Test::Unit::TestCase
     vbox = factory.create_vbox dialog
     factory.create_label vbox, "Hello, Wörld!"
     factory.create_push_button vbox, "&OK"
-    event = dialog.wait_for_event
     dialog.destroy
   end
 end

--- a/libyui/package/libyui.spec
+++ b/libyui/package/libyui.spec
@@ -134,6 +134,6 @@ install -m0644 ../COPYING* $RPM_BUILD_ROOT/%{_docdir}/%{bin_name}/
 %{_datadir}/libyui/buildtools
 %doc %{_docdir}/%{bin_name}/examples
 %{_libdir}/pkgconfig/%{name}.pc
-# %{_libdir}/cmake/%{name}
+# %%{_libdir}/cmake/%{name}
 
 %changelog


### PR DESCRIPTION
- Fixed warnings reported in GitHub Actions
- See https://github.com/libyui/libyui/runs/2122387745#step:5:6

```
warning: Macro expanded in comment on line 134: %{_libdir}/cmake/%{name}

libyui-bindings/swig/ruby/examples/hello_world.rb:19: warning: assigned but unused variable - event
libyui-bindings/swig/ruby/examples/combo_box1.rb:54: warning: statement not reached
libyui-bindings/swig/ruby/examples/combo_box1.rb:93: warning: mismatched indentations at 'end' with 'if' at 51
libyui-bindings/swig/ruby/examples/combo_box1.rb:94: warning: mismatched indentations at 'end' with 'if' at 46
```