### PR TITLE
GCC 11: fix compilation

### DIFF
--- a/libyui-ncurses-pkg/src/NCPkgFilterPattern.cc
+++ b/libyui-ncurses-pkg/src/NCPkgFilterPattern.cc
@@ -73,7 +73,7 @@ using std::endl;
 
 struct paircmp
 {
-    bool operator() (std::pair<std::string, std::string> p1, std::pair<std::string, std::string> p2)
+    bool operator() (std::pair<std::string, std::string> p1, std::pair<std::string, std::string> p2) const
     {
 	if ( p1.second != p2.second )
             return p1.second < p2.second;


### PR DESCRIPTION
It fixes the following error:

```
/home/marxin/bin/gcc/include/c++/11.0.0/bits/stl_tree.h:762:23: error: static assertion failed: comparison object must be invocable with two arguments of key type
  762 |         static_assert(__is_invocable<_Compare&, const _Key&, const _Key&>{},
      |                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Handles error seen here:
https://build.opensuse.org/package/live_build_log/openSUSE:Factory:Staging:Gcc7/libyui:libyui-ncurses-pkg/standard/x86_64