### PR TITLE
Second round: build libyui-gtk and libyui-mga with the new cmakefiles

### DIFF
--- a/libyui-bindings/swig/mono/CMakeLists.txt
+++ b/libyui-bindings/swig/mono/CMakeLists.txt
@@ -8,7 +8,7 @@
 #
 
 IF (NOT MONO_LIBRARIES)
-   SET (MONO_LIBRARIES "/usr/lib/mono")
+   SET (MONO_LIBRARIES "${CMAKE_INSTALL_PREFIX}/lib/mono")
 ENDIF (NOT MONO_LIBRARIES)
 
 # SWIG_OUPUT is per-target

--- a/libyui/pkgconfig/libyui.pc.in
+++ b/libyui/pkgconfig/libyui.pc.in
@@ -10,7 +10,7 @@ exec_prefix=${prefix}
 datarootdir=${exec_prefix}/share
 datadir=${datarootdir}/libyui
 libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
-includedir=${exec_prefix}/include/yui
+includedir=${prefix}/include
 plugindir=${exec_prefix}/@CMAKE_INSTALL_DIR@yui
 
 soversion_major=@SONAME_MAJOR@
@@ -23,4 +23,4 @@ Version: @VERSION@
 Description: libyui - GUI-abstraction library
 Libs: -L${libdir} -lyui
 Libs.private: -ldl -lpthread
-Cflags: -I${includedir}
+Cflags: -I${includedir}/yui -I${includedir}

--- a/libyui/src/CMakeLists.txt
+++ b/libyui/src/CMakeLists.txt
@@ -112,7 +112,13 @@ set( SOURCES
   )
 
 
+# Generate Libyui_config.h where some CMake variables are expanded
+# for use in the C++ code.
+configure_file( Libyui_config.h.in Libyui_config.h )
+
 set( HEADERS
+  ${CMAKE_CURRENT_BINARY_DIR}/Libyui_config.h
+
   YUI.h
   YApplication.h
   YWidgetFactory.h
@@ -225,9 +231,6 @@ add_library( ${TARGETLIB} SHARED ${SOURCES} ${HEADERS} )
 # Include directories and compile options
 #
 
-# Generate Libyui_config.h where some CMake variables are expanded
-# for use in the C++ code. This file is NOT installed upon "make install".
-configure_file( Libyui_config.h.in Libyui_config.h )
 target_include_directories( ${TARGETLIB} PUBLIC ${CMAKE_CURRENT_BINARY_DIR} )
 
 # Add more compile options to this target in addition to those


### PR DESCRIPTION
Continuing fixes for https://github.com/libyui/libyui/issues/9 which really stands for "new build system broke libyui-gtk and libyui-mga"