### PR TITLE
Code Cleanup

### DIFF
--- a/libyui-qt-pkg/src/YQPatternSelector.cc
+++ b/libyui-qt-pkg/src/YQPatternSelector.cc
@@ -41,6 +41,7 @@
 #include <QHeaderView>
 #include <QPushButton>
 #include <QSplitter>
+#include <QLayout>
 
 #include "YQPatternSelector.h"
 #include "YQPkgConflictDialog.h"

--- a/libyui-qt/src/QY2Styler.cc
+++ b/libyui-qt/src/QY2Styler.cc
@@ -299,7 +299,7 @@ void QY2Styler::registerChildWidget( QWidget * parent, QWidget * widget )
 {
     // Don't use yuiDebug() here - deadlock (reason unknown so far) in thread handling!
 
-    qDebug() << "Registering " << widget << " for parent " << parent << "\n";
+    // qDebug() << "Registering " << widget << " for parent " << parent << "\n";
     widget->installEventFilter( this );
     _children[parent].push_back( widget );
 }

--- a/libyui-qt/src/YQDialog.cc
+++ b/libyui-qt/src/YQDialog.cc
@@ -30,7 +30,6 @@
 #include <qpushbutton.h>
 #include <qmessagebox.h>
 #include <QDesktopWidget>
-#include <QDebug>
 
 #include "YQUI.h"
 #include "YQi18n.h"
@@ -857,7 +856,6 @@ YQDialog::center( QWidget * dialog, QWidget * parent )
 
     pos += parent->mapToGlobal( QPoint( 0, 0 ) );
     pos = dialog->mapToParent( dialog->mapFromGlobal( pos ) );
-    qDebug() << pos;
     dialog->move( pos );
 }
 

--- a/libyui-qt/src/YQDialog.cc
+++ b/libyui-qt/src/YQDialog.cc
@@ -27,22 +27,26 @@
 
 #define YUILogComponent "qt-ui"
 #include <yui/YUILog.h>
-#include <qpushbutton.h>
-#include <qmessagebox.h>
+
+#include <yui/YApplication.h>
+#include <yui/YDialogSpy.h>
+#include <yui/YEvent.h>
+
+#include <QPushButton>
+#include <QMessageBox>
 #include <QDesktopWidget>
 
-#include "YQUI.h"
-#include "YQi18n.h"
-#include <yui/YEvent.h>
+#include "QY2StyleEditor.h"
+#include "QY2Styler.h"
+
 #include "YQDialog.h"
 #include "YQGenericButton.h"
-#include "YQWizardButton.h"
-#include "YQWizard.h"
 #include "YQMainWinDock.h"
-#include <yui/YDialogSpy.h>
-#include <yui/YApplication.h>
-#include "QY2Styler.h"
-#include "QY2StyleEditor.h"
+#include "YQUI.h"
+#include "YQWizard.h"
+#include "YQWizardButton.h"
+#include "YQi18n.h"
+
 
 #define YQMainDialogWFlags	Qt::Widget
 #define YQPopupDialogWFlags     Qt::Dialog

--- a/libyui-qt/src/YQDialog.h
+++ b/libyui-qt/src/YQDialog.h
@@ -30,6 +30,9 @@
 #include <QEvent>
 #include <QWidget>
 #include <QPalette>
+#include <QEvent>
+#include <QCloseEvent>
+
 #include <yui/YDialog.h>
 
 class YQGenericButton;

--- a/libyui-qt/src/YQWizard.cc
+++ b/libyui-qt/src/YQWizard.cc
@@ -185,6 +185,7 @@ YQWizard::YQWizard( YWidget *		parent,
 YQWizard::~YQWizard()
 {
     deleteSteps();
+
     if ( this == main_wizard )
     {
 	main_wizard = 0;
@@ -641,7 +642,7 @@ void YQWizard::selectTreeItem( const string & id )
 	{
 	    YQSignalBlocker sigBlocker( _tree );
 
-      _tree->setCurrentItem(item);
+            _tree->setCurrentItem(item);
 	    _tree->scrollToItem(item);
 	}
     }
@@ -759,19 +760,20 @@ QWidget *YQWizard::layoutWorkArea( QWidget * parent )
     // Dialog icon and heading
     //
 
-    if (titleIsOnTheLeft()) {
-      QHBoxLayout *bigHBox = new QHBoxLayout();
-      innerbox->addLayout( bigHBox );
+    if ( titleIsOnTheLeft() )
+    {
+        QHBoxLayout *bigHBox = new QHBoxLayout();
+        innerbox->addLayout( bigHBox );
 
-      leftInnerBox = new QVBoxLayout();
-      leftInnerBox->setObjectName( "LeftInnerBox" );
-      bigHBox->addLayout( leftInnerBox );
-      bigHBox->setStretchFactor( leftInnerBox, 1 );
+        leftInnerBox = new QVBoxLayout();
+        leftInnerBox->setObjectName( "LeftInnerBox" );
+        bigHBox->addLayout( leftInnerBox );
+        bigHBox->setStretchFactor( leftInnerBox, 1 );
 
-      rightInnerBox = new QVBoxLayout();
-      rightInnerBox->setObjectName( "RightInnerBox" );
-      bigHBox->addLayout( rightInnerBox );
-      bigHBox->setStretchFactor( rightInnerBox, 2 );
+        rightInnerBox = new QVBoxLayout();
+        rightInnerBox->setObjectName( "RightInnerBox" );
+        bigHBox->addLayout( rightInnerBox );
+        bigHBox->setStretchFactor( rightInnerBox, 2 );
     }
 
     QHBoxLayout * headingHBox = new QHBoxLayout();
@@ -792,7 +794,7 @@ QWidget *YQWizard::layoutWorkArea( QWidget * parent )
     _dialogHeading->setWordWrap( true );
     _dialogHeading->setTextFormat( Qt::PlainText );
     _dialogHeading->setSizePolicy( QSizePolicy( QSizePolicy::Expanding, QSizePolicy::Minimum ) ); // hor/vert
-    _dialogHeading->setObjectName( (titleIsOnTheLeft())? "DialogHeadingLeft" : "DialogHeadingTop" ) ;
+    _dialogHeading->setObjectName( titleIsOnTheLeft() ? "DialogHeadingLeft" : "DialogHeadingTop" ) ;
 
     //
     // Client area (the part that belongs to the YCP application)
@@ -902,7 +904,7 @@ QLayout *YQWizard::layoutButtonBox( QWidget * parent )
     YUI_CHECK_NEW( _releaseNotesButton );
     hbox->addWidget( (QWidget *) _releaseNotesButton->widgetRep() );
     connect( _releaseNotesButton,      &pclass(_releaseNotesButton)::clicked,
-            this,                      &pclass(this)::showReleaseNotes );
+             this,                      &pclass(this)::showReleaseNotes );
 
 
     if (_releaseNotesButtonId == "")
@@ -959,10 +961,12 @@ QLayout *YQWizard::layoutButtonBox( QWidget * parent )
     return hbox;
 }
 
+
 bool YQWizard::titleIsOnTheLeft()
 {
     return wizardMode() == YWizardMode_TitleOnLeft;
 }
+
 
 void YQWizard::destroyButtons()
 {
@@ -1037,10 +1041,12 @@ void YQWizard::setDialogTitle( const string & titleText )
 	topLevelWidget()->setWindowTitle( YQUI::ui()->applicationTitle() );
 }
 
+
 string YQWizard::getDialogTitle()
 {
-	return toUTF8(topLevelWidget()->windowTitle());
+    return toUTF8( topLevelWidget()->windowTitle() );
 }
+
 
 void YQWizard::setDialogHeading( const string & headingText )
 {
@@ -1061,10 +1067,10 @@ void YQWizard::setDialogHeading( const string & headingText )
 
 string YQWizard::getDialogHeading()
 {
-	if (_dialogHeading)
-	    return toUTF8(_dialogHeading->text());
-	else
-            return "";
+    if (_dialogHeading)
+        return toUTF8(_dialogHeading->text());
+    else
+        return "";
 }
 
 string YQWizard::debugLabel() const
@@ -1348,11 +1354,13 @@ void YQWizard::setSize( int newWidth, int newHeight )
     resizeClientArea();
 }
 
+
 void YQWizard::resizeClientArea()
 {
     QSize contentsRect = _clientArea->contentsRect().size();
     _contents->setSize( contentsRect.width(), contentsRect.height() );
 }
+
 
 bool YQWizard::eventFilter( QObject * obj, QEvent * ev )
 {
@@ -1379,7 +1387,8 @@ void YQWizard::setButtonLabel( YPushButton * button, const string & newLabel )
 
     YQWizardButton * wizardButton = dynamic_cast<YQWizardButton *> (button);
 
-    if ( wizardButton ) {
+    if ( wizardButton )
+    {
         // QWizardButton only implements hide and show, not setVisible
         if ( newLabel.empty() )
             wizardButton->hide();

--- a/libyui-qt/src/YQWizard.cc
+++ b/libyui-qt/src/YQWizard.cc
@@ -24,49 +24,36 @@
 
 /-*/
 
+
 #include "YQWizard.h"
+
 #define YUILogComponent "qt-wizard"
 #include <yui/YUILog.h>
 
-#include <string>
-#include <yui/YShortcut.h>
+#include <yui/YApplication.h>
 #include <yui/YEvent.h>
+#include <yui/YReplacePoint.h>
+#include <yui/YWidgetFactory.h>
 
-#include <QDialog>
-#include <QPainter>
-#include <QStackedWidget>
-#include <qimage.h>
-#include <qlabel.h>
-#include <qlayout.h>
-#include <qmenubar.h>
-#include <qobject.h>
-#include <qpixmap.h>
-#include <qpushbutton.h>
-#include <qregexp.h>
-#include <qtabwidget.h>
-#include <qtoolbutton.h>
-#include <QGraphicsDropShadowEffect>
 #include <QFileInfo>
-
-#include "QY2ListView.h"
-#include "QY2Styler.h"
-#include "QY2HelpDialog.h"
-#include "QY2RelNotesDialog.h"
 #include <QGridLayout>
 #include <QHeaderView>
-#include <qevent.h>
+#include <QLabel>
+#include <QLayout>
+#include <QMenuBar>
+#include <QPixmap>
+#include <QStackedWidget>
+
+#include "QY2HelpDialog.h"
+#include "QY2ListView.h"
+#include "QY2RelNotesDialog.h"
+#include "QY2Styler.h"
 
 #include "utf8.h"
+#include "YQAlignment.h"
 #include "YQi18n.h"
 #include "YQUI.h"
-#include "YQApplication.h"
-#include "YQDialog.h"
-#include "YQAlignment.h"
-#include "YQReplacePoint.h"
-#include "YQEmpty.h"
-#include "YQLabel.h"
 #include "YQWizardButton.h"
-#include "YQWidgetFactory.h"
 #include "YQSignalBlocker.h"
 #include "YQMainWinDock.h"
 
@@ -1198,6 +1185,7 @@ void YQWizard::showReleaseNotes()
     }
 
     std::map<string,string> relnotes = YUI::application()->releaseNotes();
+
     if ( relnotes.size() == 0)
     {
         return;

--- a/libyui-qt/src/YQWizard.cc
+++ b/libyui-qt/src/YQWizard.cc
@@ -100,9 +100,9 @@ YQWizard::YQWizard( YWidget *		parent,
     , _backButtonLabel( backButtonLabel )
     , _abortButtonLabel( abortButtonLabel )
     , _nextButtonLabel( nextButtonLabel )
-    , _helpDlg ( NULL )
-    , _hotkeysDlg ( NULL )
-    , _relNotesDlg ( NULL )
+    , _helpDialog ( NULL )
+    , _hotkeysDialog ( NULL )
+    , _relNotesDialog ( NULL )
 {
     setObjectName( "wizard" );
     setSizePolicy( QSizePolicy( QSizePolicy::Expanding, QSizePolicy::Expanding ) );
@@ -195,9 +195,9 @@ YQWizard::~YQWizard()
 	main_wizard->setSizes( sizes() );
     }
 
-    delete _helpDlg;
-    delete _hotkeysDlg;
-    delete _relNotesDlg;
+    delete _helpDialog;
+    delete _hotkeysDialog;
+    delete _relNotesDialog;
 
     QY2Styler::styler()->unregisterWidget( this );
     topLevelWidget()->setWindowIcon( _previousWindowIcon );
@@ -1064,7 +1064,7 @@ string YQWizard::getDialogHeading()
 	if (_dialogHeading)
 	    return toUTF8(_dialogHeading->text());
 	else
-		return "";
+            return "";
 }
 
 string YQWizard::debugLabel() const
@@ -1122,17 +1122,17 @@ void YQWizard::slotNextClicked()
 
 void YQWizard::showHelp()
 {
-    if (!_helpDlg)
-	_helpDlg = new QY2HelpDialog ( _qHelpText, NULL );
+    if ( !_helpDialog )
+	_helpDialog = new QY2HelpDialog ( _qHelpText, NULL );
     else
     {
-	_helpDlg->setHelpText( _qHelpText );
-	_helpDlg->hide(); // workaround for icewm (see: bnc #397083)
+	_helpDialog->setHelpText( _qHelpText );
+	_helpDialog->hide(); // workaround for icewm (see: bnc #397083)
     }
 
-    _helpDlg->show();
-    _helpDlg->raise();
-    _helpDlg->activateWindow();
+    _helpDialog->show();
+    _helpDialog->raise();
+    _helpDialog->activateWindow();
 }
 
 
@@ -1172,22 +1172,22 @@ void YQWizard::showHotkeys()
         "</dl>"
         );
 
-    if (!_hotkeysDlg)
-	_hotkeysDlg = new QY2HelpDialog ( _qHotkeysText , NULL );
+    if (!_hotkeysDialog)
+	_hotkeysDialog = new QY2HelpDialog ( _qHotkeysText , NULL );
 
-    _hotkeysDlg->show();
-    _hotkeysDlg->raise();
-    _hotkeysDlg->activateWindow();
+    _hotkeysDialog->show();
+    _hotkeysDialog->raise();
+    _hotkeysDialog->activateWindow();
 }
 
 
 void YQWizard::showReleaseNotes()
 {
-    if (!_relNotesDlg)
-	_relNotesDlg = new QY2RelNotesDialog ( NULL );
+    if (!_relNotesDialog)
+	_relNotesDialog = new QY2RelNotesDialog ( NULL );
     else
     {
-	_relNotesDlg->hide(); // workaround for icewm (see: bnc #397083)
+	_relNotesDialog->hide(); // workaround for icewm (see: bnc #397083)
     }
 
     std::map<string,string> relnotes = YUI::application()->releaseNotes();
@@ -1195,10 +1195,10 @@ void YQWizard::showReleaseNotes()
     {
         return;
     }
-    _relNotesDlg->setRelNotes( relnotes );
-    _relNotesDlg->show();
-    _relNotesDlg->raise();
-    _relNotesDlg->activateWindow();
+    _relNotesDialog->setRelNotes( relnotes );
+    _relNotesDialog->show();
+    _relNotesDialog->raise();
+    _relNotesDialog->activateWindow();
 }
 
 
@@ -1445,14 +1445,14 @@ void YQWizard::retranslateInternalButtons()
         // Qt handles duplicate shortcuts, it can be kept (bnc#880983)
 	_releaseNotesButton->setLabel( _( "&Release Notes" ) );
 
-    if ( _helpDlg )
-	_helpDlg->retranslate();
+    if ( _helpDialog )
+	_helpDialog->retranslate();
 
-    if ( _hotkeysDlg )
-	_hotkeysDlg->retranslate();
+    if ( _hotkeysDialog )
+	_hotkeysDialog->retranslate();
 
-    if ( _relNotesDlg )
-	_relNotesDlg->retranslate();
+    if ( _relNotesDialog )
+	_relNotesDialog->retranslate();
 
 }
 

--- a/libyui-qt/src/YQWizard.cc
+++ b/libyui-qt/src/YQWizard.cc
@@ -30,6 +30,7 @@
 
 #include <string>
 #include <yui/YShortcut.h>
+#include <yui/YEvent.h>
 
 #include <QDialog>
 #include <QPainter>
@@ -67,7 +68,6 @@
 #include "YQWizardButton.h"
 #include "YQWidgetFactory.h"
 #include "YQSignalBlocker.h"
-#include <yui/YEvent.h>
 #include "YQMainWinDock.h"
 
 
@@ -79,11 +79,11 @@ using std::string;
 
 #define TEXTDOMAIN "qt"
 
-#define USE_ICON_ON_HELP_BUTTON		0
 
-YQWizard *YQWizard::main_wizard = 0;
-string YQWizard::_releaseNotesButtonId = "";
-string YQWizard::_releaseNotesButtonLabel = "";
+YQWizard * YQWizard::main_wizard              = 0;
+string     YQWizard::_releaseNotesButtonId    = "";
+string     YQWizard::_releaseNotesButtonLabel = "";
+
 
 YQWizard::YQWizard( YWidget *		parent,
 		    const string & 	backButtonLabel,
@@ -100,9 +100,9 @@ YQWizard::YQWizard( YWidget *		parent,
     , _backButtonLabel( backButtonLabel )
     , _abortButtonLabel( abortButtonLabel )
     , _nextButtonLabel( nextButtonLabel )
-    , _helpDialog ( NULL )
-    , _hotkeysDialog ( NULL )
-    , _relNotesDialog ( NULL )
+    , _helpDialog( NULL )
+    , _hotkeysDialog( NULL )
+    , _relNotesDialog( NULL )
 {
     setObjectName( "wizard" );
     setSizePolicy( QSizePolicy( QSizePolicy::Expanding, QSizePolicy::Expanding ) );
@@ -113,7 +113,7 @@ YQWizard::YQWizard( YWidget *		parent,
 
     setWidgetRep( this );
 
-    //either main wizard with `opt(`stepsEnabled), or sub-wizard of steps-enabled wizard
+    // either main wizard with `opt(`stepsEnabled), or sub-wizard of steps-enabled wizard
     _stepsEnabled = (wizardMode == YWizardMode_Steps);
     _treeEnabled  = (wizardMode == YWizardMode_Tree);
 
@@ -161,8 +161,8 @@ YQWizard::YQWizard( YWidget *		parent,
     setStretchFactor( indexOf( _workArea ), 1 );
     setCollapsible( indexOf( _sideBar ), false );
 
-    /* If steps are enabled, we want to delay
-       the registering for after we have steps registered */
+    // If steps are enabled, we want to delay registration until after we registered steps
+
     if ( !_stepsEnabled )
 	QY2Styler::styler()->registerWidget( this );
 
@@ -490,6 +490,7 @@ void YQWizard::setCurrentStep( const string & id )
     updateStepStates();
 }
 
+
 void YQWizard::copySteps( YQWizard *wizard)
 {
     QList<Step*> _oldSteps = wizard->stepsList();
@@ -662,7 +663,7 @@ void YQWizard::sendTreeEvent( QTreeWidgetItem * listViewItem )
 
 
 void YQWizard::treeSelectionChanged()
-{ //FIXME is currentItem correct or selected.first
+{
     if ( _tree )
 	sendTreeEvent( _tree->currentItem() );
 }
@@ -695,7 +696,8 @@ QWidget *YQWizard::layoutWorkArea( QWidget * parent )
     QVBoxLayout *vbox = new QVBoxLayout( _workArea );
     YUI_CHECK_NEW( vbox );
 
-    // add the logo on the top
+    // Add the logo at the top
+
     if (YUI::application()->showProductLogo())
     {
         QWidget * logoWidget = new QWidget;
@@ -778,7 +780,6 @@ QWidget *YQWizard::layoutWorkArea( QWidget * parent )
 
     QHBoxLayout * headingHBox = new QHBoxLayout();
     YUI_CHECK_NEW( headingHBox );
-    //headingHBox->setSizePolicy( QSizePolicy( QSizePolicy::Expanding, QSizePolicy::Minimum ) ); // hor/vert
     leftInnerBox->addLayout( headingHBox );
 
     _dialogIcon = new QLabel( _workArea );

--- a/libyui-qt/src/YQWizard.h
+++ b/libyui-qt/src/YQWizard.h
@@ -26,39 +26,28 @@
 #ifndef YQWizard_h
 #define YQWizard_h
 
-#include <string>
-#include <vector>
-
-#include <qpixmap.h>
-#include <qstringlist.h>
-#include "QY2ListView.h"
-#include <QGridLayout>
-#include <QSplitter>
-#include <qlabel.h>
-#include <QMenu>
-#include <QAction>
-#include <qevent.h>
 #include <yui/YWizard.h>
+
+#include <string>
+
+#include <qstringlist.h>
+#include <QSplitter>
+
+#include "QY2ListView.h"
 #include "YQWizardButton.h"
 
-using std::vector;
-
-class QGridLayout;
+class QAction;
+class QEvent;
 class QFrame;
-class QSplitter;
 class QLabel;
 class QMenuBar;
 class QPushButton;
-class QSpacerItem;
-class QToolButton;
 class QStackedWidget;
-class YReplacePoint;
 class QTreeWidgetItem;
-class YQAlignment;
-class YQReplacePoint;
-class QY2ListView;
 class QY2HelpDialog;
 class QY2RelNotesDialog;
+class YQAlignment;
+class YReplacePoint;
 
 
 class YQWizard : public QSplitter, public YWizard
@@ -73,11 +62,11 @@ public:
     /**
      * Constructor.
      **/
-    YQWizard( YWidget * 	parent,
+    YQWizard( YWidget *                 parent,
 	      const std::string &	backButtonLabel,
 	      const std::string & 	abortButtonLabel,
 	      const std::string & 	nextButtonLabel,
-	      YWizardMode	wizardMode = YWizardMode_Standard );
+	      YWizardMode               wizardMode = YWizardMode_Standard );
 
     /**
      * Destructor.

--- a/libyui-qt/src/YQWizard.h
+++ b/libyui-qt/src/YQWizard.h
@@ -590,41 +590,41 @@ protected:
     QString     _qHelpText;
     QString     _qHotkeysText;
 
-    QY2HelpDialog *	_helpDlg;
-    QY2HelpDialog *	_hotkeysDlg;
-    QY2RelNotesDialog *	_relNotesDlg;
+    QY2HelpDialog *	_helpDialog;
+    QY2HelpDialog *	_hotkeysDialog;
+    QY2RelNotesDialog *	_relNotesDialog;
 
     QStackedWidget *	_sideBar;
     QWidget     *       _stepsPanel;
     YQWizardButton *	_releaseNotesButton;
-    static std::string		 _releaseNotesButtonId;
-    static std::string		 _releaseNotesButtonLabel;
+    static std::string	_releaseNotesButtonId;
+    static std::string	_releaseNotesButtonLabel;
     YQWizardButton *	_helpButton;
     QAction *           _helpAction;
     QAction *           _hotkeysAction;
-    QPushButton *		_stepsButton;
-    QPushButton *		_treeButton;
-    QFrame *		    _treePanel;
-    QY2ListView *		_tree;
+    QPushButton *	_stepsButton;
+    QPushButton *	_treeButton;
+    QFrame *		_treePanel;
+    QY2ListView *	_tree;
 
     QFrame *            _workArea;
     QWidget *		_clientArea;
-    QMenuBar *		        _menuBar;
-    QLabel *		    _dialogIcon;
-    QLabel *	            _dialogLogo;
-    QLabel *	            _dialogBanner;    
-    QLabel *		    _dialogHeading;
-    YQAlignment *    	    _contents;
-    YQWizardButton *	    _backButton;
-    YQWizardButton *	    _abortButton;
-    YQWizardButton *	    _nextButton;
+    QMenuBar *		_menuBar;
+    QLabel *		_dialogIcon;
+    QLabel *	        _dialogLogo;
+    QLabel *	        _dialogBanner;    
+    QLabel *		_dialogHeading;
+    YQAlignment *    	_contents;
+    YQWizardButton *	_backButton;
+    YQWizardButton *	_abortButton;
+    YQWizardButton *	_nextButton;
     YReplacePoint *	_contentsReplacePoint;
 
-    QList<YQWizard::Step*> 	_stepsList;
+    QList<YQWizard::Step*>              _stepsList;
     QHash<QString,YQWizard::Step*>	_stepsIDs;
     QHash<QString,YQWizard::TreeItem*>	_treeIDs;
     QHash<QString,QMenu*>		_menuIDs;
-    QHash<QAction*, std::string>		_menuEntryIDs;
+    QHash<QAction*, std::string>	_menuEntryIDs;
 
     QIcon _previousWindowIcon;
 

--- a/libyui/src/YDialogSpy.cc
+++ b/libyui/src/YDialogSpy.cc
@@ -189,12 +189,13 @@ private:
     void editWidget( YWidget *widget, const string & property="Label" );
 };
 
+
 /**
  * Destructor - switch off widget highlighting at the end
  */
 YDialogSpyPrivate::~YDialogSpyPrivate()
 {
-    highlightWidget(false);
+    highlightWidget( false );
 }
 
 
@@ -204,10 +205,11 @@ YDialogSpyPrivate::~YDialogSpyPrivate()
  * @param target the target dialog which will be examined
  * @param widgetTree where to display the structure
 */
-void fillWidgetTree(YDialog *target, YTree *widgetTree)
+void fillWidgetTree( YDialog *target, YTree *widgetTree )
 {
     YWidgetTreeItem * rootItem = new YWidgetTreeItem( target, true );
     YUI_CHECK_NEW( rootItem );
+
     fillTree( rootItem, target->childrenBegin(), target->childrenEnd(), 1 );
     widgetTree->addItem( rootItem );
     widgetTree->rebuildTree();
@@ -242,23 +244,24 @@ YDialogSpy::YDialogSpy( YDialog * targetDialog )
 
     auto minSize = fac->createMinSize( vbox, TREE_WIDTH, TREE_HEIGHT );
     minSize->setWeight( YD_VERT, TREE_VWEIGHT );
-    priv->widgetTree	 = fac->createTree( minSize, "Widget &Tree", false );
+    priv->widgetTree = fac->createTree( minSize, "Widget &Tree", false );
     priv->widgetTree->setNotify( true );
 
     fillWidgetTree(priv->targetDialog, priv->widgetTree);
 
     auto hbox = fac->createHBox( vbox );
     priv->propButton = fac->createPushButton( hbox, "&Properties >>>" );
-
     priv->addButton = fac->createMenuButton( hbox, "&Add" );
+
     YItemCollection add_items;
-    YMenuItem *menu_info = new YMenuItem( "Info" );
-    YMenuItem *menu_buttons = new YMenuItem( "Buttons" );
-    YMenuItem *menu_input = new YMenuItem( "Input" );
-    YMenuItem *menu_align = new YMenuItem( "Alignment" );
-    YMenuItem *menu_size = new YMenuItem( "Size" );
-    YMenuItem *menu_containers = new YMenuItem( "Containers" );
-    YMenuItem *menu_special = new YMenuItem( "Special" );
+    YMenuItem *menu_info        = new YMenuItem( "Info" );
+    YMenuItem *menu_buttons     = new YMenuItem( "Buttons" );
+    YMenuItem *menu_input       = new YMenuItem( "Input" );
+    YMenuItem *menu_align       = new YMenuItem( "Alignment" );
+    YMenuItem *menu_size        = new YMenuItem( "Size" );
+    YMenuItem *menu_containers  = new YMenuItem( "Containers" );
+    YMenuItem *menu_special     = new YMenuItem( "Special" );
+
     add_items.push_back( menu_info );
     add_items.push_back( menu_buttons );
     add_items.push_back( menu_input );
@@ -320,20 +323,21 @@ YDialogSpy::YDialogSpy( YDialog * targetDialog )
     new YMenuItem( menu_special, "DumbTab" );
     new YMenuItem( menu_special, "Graph" );
     new YMenuItem( menu_special, "Slider" );
-    new YMenuItem( menu_input, "TimeField" );
+    new YMenuItem( menu_input,   "TimeField" );
     new YMenuItem( menu_special, "TimezoneSelector" );
 
     priv->addButton->addItems( add_items );
 
     priv->deleteButton = fac->createPushButton( hbox, "&Delete" );
-    priv->upButton = fac->createPushButton( hbox, "⬆ Up" );
-    priv->downButton = fac->createPushButton( hbox, "⬇ Down" );
+    priv->upButton     = fac->createPushButton( hbox, "⬆ Up" );
+    priv->downButton   = fac->createPushButton( hbox, "⬇ Down" );
 
     priv->propReplacePoint = fac->createReplacePoint( vbox );
     fac->createEmpty( priv->propReplacePoint );
 
     priv->selectedWidgetChanged();
 }
+
 
 /**
  * Destructor
@@ -344,7 +348,10 @@ YDialogSpy::~YDialogSpy()
 	priv->spyDialog->destroy();
 }
 
-/** Is the property dialog displayed?
+
+/**
+ * Is the property dialog displayed?
+ *
  * @return true if the dialog is displayed
  */
 bool YDialogSpyPrivate::propertiesShown() const
@@ -352,13 +359,15 @@ bool YDialogSpyPrivate::propertiesShown() const
     return propTable != nullptr;
 }
 
+
 /**
  * Highlight the currently selected widget in the spy dialog
  */
 void YDialogSpyPrivate::highlightWidget(bool enable)
 {
-    if (targetDialog) targetDialog->highlight( enable ? selectedWidget() : nullptr);
+    if (targetDialog) targetDialog->highlight( enable ? selectedWidget() : nullptr );
 }
+
 
 /**
  * Display details about the currently selected widget
@@ -371,8 +380,7 @@ void YDialogSpyPrivate::showProperties()
 	propReplacePoint->setWeight( YD_VERT, PROP_VWEIGHT );
 
 	auto fac = YUI::widgetFactory();
-	auto minSize = fac->createMinSize( propReplacePoint,
-						   PROP_WIDTH, PROP_HEIGHT );
+	auto minSize = fac->createMinSize( propReplacePoint, PROP_WIDTH, PROP_HEIGHT );
 	auto header = new YTableHeader();
 	YUI_CHECK_NEW( header );
 	header->addColumn( "Property" );
@@ -386,6 +394,7 @@ void YDialogSpyPrivate::showProperties()
 	propReplacePoint->showChild();
 	spyDialog->recalcLayout();
 }
+
 
 /**
  * Hide property details
@@ -481,6 +490,7 @@ void YDialogSpyPrivate::refreshProperties()
 
 /**
  * Fill the widget tree dialog
+ *
  * @param parent    widget tree item
  * @param begin	    iterator pointing to the first item
  * @param end	    iterator pointing to the last item
@@ -501,6 +511,7 @@ void fillTree( YWidgetTreeItem *		parent,
     }
 }
 
+
 /**
  * The main loop of the spy dialog
  */
@@ -511,44 +522,48 @@ void YDialogSpy::exec()
     while ( true )
     {
 	auto event = priv->spyDialog->waitForEvent();
-	yuiMilestone() << "event: " << event;
-	if (!event) continue;
+	// yuiDebug() << "event: " << event << endl;
+	if ( ! event ) continue;
 
 	// window manager "close window" button
-	if ( event->eventType() == YEvent::CancelEvent ) break;
+	if ( event->eventType() == YEvent::CancelEvent )
+            break;
 	else if ( event->eventType() == YEvent::MenuEvent)
 	{
-	    YMenuItem * menu_item = dynamic_cast<YMenuItem *>(event->item());
+	    YMenuItem * menu_item = dynamic_cast<YMenuItem *>( event->item() );
 
 	    // TODO: handle the export menu item
 	    // if (menu_item == priv->exportMenu) continue;
 
 	    // closing from menu
-	    if (menu_item == priv->closeItem) break;
+	    if ( menu_item == priv->closeItem )
+                break;
 
 	    // handle all unhandled menu items as "Add" menu items, this is much
 	    // simpler than comparing it with the huge amount of menu item pointers
-	    if (menu_item)
+	    if ( menu_item )
 	    {
 		auto menu_label = menu_item->label();
-		yuiMilestone() << "Activated menu item: " << menu_label << endl;
-		priv->addWidget(menu_label);
+		// yuiDebug() << "Activated menu item: " << menu_label << endl;
+		priv->addWidget( menu_label );
 	    }
 
 	    continue;
 	}
 
 	// just make sure we do not use NULL in some unexpected case
-	if (!event->widget()) continue;
+	if ( !event->widget() )
+            continue;
 
-	if ( event->widget() == priv->upButton ) priv->moveSelectedUp();
-	else if ( event->widget() == priv->downButton)	priv->moveSelectedDown();
-	else if ( event->widget() == priv->propButton ) priv->toggleProperties();
-	else if ( event->widget() == priv->deleteButton) priv->deleteWidget();
-	else if ( event->widget() == priv->propTable )	priv->editProperty();
-	else if ( event->widget() == priv->widgetTree ) priv->selectedWidgetChanged();
+	if      ( event->widget() == priv->upButton     ) priv->moveSelectedUp();
+	else if ( event->widget() == priv->downButton   ) priv->moveSelectedDown();
+	else if ( event->widget() == priv->propButton   ) priv->toggleProperties();
+	else if ( event->widget() == priv->deleteButton ) priv->deleteWidget();
+	else if ( event->widget() == priv->propTable    ) priv->editProperty();
+	else if ( event->widget() == priv->widgetTree   ) priv->selectedWidgetChanged();
     }
 }
+
 
 /**
  * Run the spy dialog for selected UI dialog
@@ -569,16 +584,18 @@ void YDialogSpy::showDialogSpy( YDialog * dialog )
     }
 }
 
+
 /**
  * The currently selected wiget
  * @return The currently selected widget (or nullptr if nothing is selected)
  */
 YWidget * YDialogSpyPrivate::selectedWidget()
 {
-    auto item = dynamic_cast<YWidgetTreeItem *>(widgetTree->selectedItem());
+    auto item = dynamic_cast<YWidgetTreeItem *>( widgetTree->selectedItem() );
 
     return item ? item->widget() : nullptr;
 }
+
 
 /**
  * The selected item has been changed, refresh the UI
@@ -590,21 +607,27 @@ void YDialogSpyPrivate::selectedWidgetChanged()
     refreshButtonStates();
 }
 
+
 /**
  * Run the property editor for the current widget
  */
 void YDialogSpyPrivate::editProperty()
 {
-    auto selected_item = dynamic_cast<YTableItem *>(propTable->selectedItem());
-    if (!selected_item) return;
+    auto selected_item = dynamic_cast<YTableItem *>( propTable->selectedItem() );
+
+    if ( ! selected_item )
+        return;
 
     auto cell = selected_item->cell(0);
     yuiMilestone() << "editing property: " << cell->label();
 
     YPropertyEditor editor(selectedWidget());
+
     // update the property table when only the property has been changed
-    if (editor.edit(cell->label())) refreshProperties();
+    if ( editor.edit( cell->label() ) )
+        refreshProperties();
 }
+
 
 /**
  * Delete the currently selected widget
@@ -612,10 +635,14 @@ void YDialogSpyPrivate::editProperty()
 void YDialogSpyPrivate::deleteWidget()
 {
     auto w = selectedWidget();
-    if (!w) return;
+
+    if ( ! w )
+        return;
 
     auto parent = w->parent();
-    if (!parent) return;
+
+    if ( ! parent )
+        return;
 
     yuiMilestone() << "removing widget: " << w << endl;
     parent->removeChild(w);
@@ -626,11 +653,11 @@ void YDialogSpyPrivate::deleteWidget()
     }
 
     // any other child left after the removal?
-    if (!parent->hasChildren())
+    if ( ! parent->hasChildren() )
     {
 	// add an Empty widget to have a valid widget tree
 	// e.g. empty VBoxes are not allowed
-	YUI::widgetFactory()->createEmpty(parent);
+	YUI::widgetFactory()->createEmpty( parent );
     }
 
     targetDialogUpdated();
@@ -638,61 +665,74 @@ void YDialogSpyPrivate::deleteWidget()
 
 /**
  * Helper method - Is the widget a VBox or Hbox?
+ *
  * @param  widget the widget
- * @return	  true if the widget is a VBox or HBox
+ * @return true if the widget is a VBox or HBox
  */
 bool isBox(const YWidget *widget)
 {
-    return dynamic_cast<const YLayoutBox *>(widget);
+    return dynamic_cast<const YLayoutBox *>( widget );
 }
+
 
 /**
  * Helper method - Is the widget a VBox?
+ *
  * @param  widget the widget
- * @return	  true if the widget is a VBox
+ * @return true if the widget is a VBox
  */
-bool isVBox(const YWidget *widget)
+bool isVBox( const YWidget *widget )
 {
-    auto box = dynamic_cast<const YLayoutBox *>(widget);
+    auto box = dynamic_cast<const YLayoutBox *>( widget );
+
     return box && box->primary() == YD_VERT;
 }
+
 
 /**
  * Move the selected widget up/left or down/right. The visual direction
  * actually depends on the widget, it just moves the widget to the begining
  * or the end of the container.
+ *
  * @param true = up move to the begining (up/left), false = to the end (down/right)
  */
-void YDialogSpyPrivate::moveSelected(Direction direction)
+void YDialogSpyPrivate::moveSelected( Direction direction )
 {
     auto target_widget = selectedWidget();
-    if (!target_widget) return;
+
+    if ( !target_widget )
+        return;
 
     auto parent = target_widget->parent();
-    if (!parent || !isBox(parent)) return;
 
-    if (direction == MOVE_UP)
+    if ( ! parent || ! isBox( parent ) )
+        return;
+
+    if ( direction == MOVE_UP )
     {
 	// the first child cannot be moved further
-	if (target_widget == parent->firstChild()) return;
+	if ( target_widget == parent->firstChild() )
+            return;
 
 	auto i = find( parent->childrenBegin(), parent->childrenEnd(), target_widget );
-	if (i != parent->childrenEnd())
+
+	if ( i != parent->childrenEnd() )
 	{
 	    // swap with the preceeding widget
 	    // Note: use a temporary variable to not rely on the argument evaluation order!
 	    auto other = i--;
-            std::swap(*other, *i);
+            std::swap( *other, *i );
 	}
     }
-    else
-    // moving down
+    else // moving down
     {
 	// the last child cannot be moved further to the end
-	if (target_widget == parent->lastChild()) return;
+	if ( target_widget == parent->lastChild() )
+            return;
 
 	auto i = find( parent->childrenBegin(), parent->childrenEnd(), target_widget );
-	if (i != parent->childrenEnd())
+
+	if ( i != parent->childrenEnd() )
 	{
 	    // swap with the succeeding widget
 	    // Note: use a temporary variable to not rely on the argument evaluation order!
@@ -706,152 +746,159 @@ void YDialogSpyPrivate::moveSelected(Direction direction)
 
 /**
  * Generic handler for adding widgets
+ *
  * @param type Type of the widget to add
  */
-void YDialogSpyPrivate::addWidget(const string &type)
+void YDialogSpyPrivate::addWidget( const string & type )
 {
     auto widget = selectedWidget();
-    if (!widget) return;
+
+    if ( ! widget )
+        return;
 
     try
     {
 	auto f = YUI::widgetFactory();
 
 	if (type == "Bottom")
-	    editWidget(f->createBottom(widget));
+	    editWidget( f->createBottom( widget ) );
 	else if (type == "BusyIndicator")
-	    editWidget(f->createBusyIndicator(widget, "Busy Indicator", 10000));
+	    editWidget( f->createBusyIndicator( widget, "Busy Indicator", 10000 ) );
 	else if (type == "ButtonBox")
-	    editWidget(f->createButtonBox(widget));
+	    editWidget( f->createButtonBox( widget ) );
 	else if (type == "ComboBox")
 	{
-	    auto cb = f->createComboBox(widget, "Combo Box");
+	    auto cb = f->createComboBox( widget, "Combo Box" );
 	    editWidget(cb);
 
-	    YPopupInternal::StringArray items(YPopupInternal::editNewStringArray("Menu Items"));
+	    YPopupInternal::StringArray items( YPopupInternal::editNewStringArray( "Menu Items" ) );
 
 	    YItemCollection add_items;
 	    // access by reference
-	    for(auto&& str: items) add_items.push_back( new YMenuItem( str ) );
+	    for ( auto && str: items )
+                add_items.push_back( new YMenuItem( str ) );
+
 	    cb->addItems( add_items );
 	}
-	else if (type == "Empty")
-	    editWidget(f->createEmpty(widget));
-	else if (type == "Frame")
-	    editWidget(f->createFrame(widget, "Frame"));
-	else if (type == "HBox")
-	    editWidget(f->createHBox(widget));
-	else if (type == "Heading")
-	    editWidget(f->createHeading(widget, "Heading"));
-	else if (type == "HSpacing")
-	    editWidget(f->createHSpacing(widget));
-	else if (type == "HStretch")
-	    editWidget(f->createHStretch(widget));
-	else if (type == "CheckBox")
-	    editWidget(f->createCheckBox(widget, "Check Box"));
-	else if (type == "CheckBoxFrame")
+	else if ( type == "Empty" )
+	    editWidget( f->createEmpty( widget ) );
+	else if ( type == "Frame" )
+	    editWidget( f->createFrame( widget, "Frame" ) );
+	else if ( type == "HBox" )
+	    editWidget( f->createHBox( widget ) );
+	else if ( type == "Heading" )
+	    editWidget( f->createHeading( widget, "Heading" ) );
+	else if ( type == "HSpacing" )
+	    editWidget( f->createHSpacing( widget ) );
+	else if ( type == "HStretch" )
+	    editWidget( f->createHStretch( widget ) );
+	else if ( type == "CheckBox" )
+	    editWidget( f->createCheckBox( widget, "Check Box" ) );
+	else if ( type == "CheckBoxFrame" )
 	    // make it checked by default
-	    editWidget(f->createCheckBoxFrame(widget, "Check Box Frame", true));
-	else if (type == "Image")
-	    editWidget(f->createImage(widget, ""));
-	else if (type == "InputField")
-	    editWidget(f->createInputField(widget, "Input"));
-	else if (type == "IntField")
-	    editWidget(f->createIntField(widget, "Integer Field", 0, 100, 50));
-	else if (type == "Label")
-	    editWidget(f->createLabel(widget, "Label"));
-	else if (type == "Left")
-	    editWidget(f->createLeft(widget));
-	else if (type == "LogView")
-	    editWidget(f->createLogView(widget, "Log View", 12));
-	else if (type == "MenuButton")
+	    editWidget( f->createCheckBoxFrame( widget, "Check Box Frame", true ) );
+	else if ( type == "Image" )
+	    editWidget( f->createImage( widget, "" ) );
+	else if ( type == "InputField" )
+	    editWidget( f->createInputField( widget, "Input" ) );
+	else if ( type == "IntField" )
+	    editWidget( f->createIntField( widget, "Integer Field", 0, 100, 50 ) );
+	else if ( type == "Label" )
+	    editWidget( f->createLabel( widget, "Label" ) );
+	else if ( type == "Left" )
+	    editWidget( f->createLeft( widget ) );
+	else if ( type == "LogView" )
+	    editWidget( f->createLogView( widget, "Log View", 12 ) );
+	else if ( type == "MenuButton" )
 	{
 	    auto menu = f->createMenuButton( widget, "Menu" );
 	    editWidget(menu);
 
-	    YPopupInternal::StringArray items(YPopupInternal::editNewStringArray("Menu Items"));
+	    YPopupInternal::StringArray items( YPopupInternal::editNewStringArray("Menu Items") );
 
 	    YItemCollection add_items;
 	    // access by reference
-	    for(auto&& str: items) add_items.push_back( new YMenuItem( str ) );
+	    for ( auto && str: items )
+                add_items.push_back( new YMenuItem( str ) );
+
 	    menu->addItems( add_items );
 	}
-	else if (type == "MinHeight")
-	    editWidget(f->createMinHeight(widget, 10));
-	else if (type == "MinWidth")
-	    editWidget(f->createMinWidth(widget, 10));
-	else if (type == "MinSize")
-	    editWidget(f->createMinSize(widget, 10, 10));
-	else if (type == "MultiLineEdit")
-	    editWidget(f->createMultiLineEdit(widget, "MultiLineEdit"));
-	else if (type == "MultiSelectionBox")
+	else if ( type == "MinHeight" )
+	    editWidget( f->createMinHeight( widget, 10) );
+	else if ( type == "MinWidth" )
+	    editWidget( f->createMinWidth( widget, 10) );
+	else if ( type == "MinSize" )
+	    editWidget( f->createMinSize( widget, 10, 10) );
+	else if ( type == "MultiLineEdit" )
+	    editWidget( f->createMultiLineEdit( widget, "MultiLineEdit" ) );
+	else if ( type == "MultiSelectionBox" )
 	{
-	    auto msb = f->createMultiSelectionBox(widget, "MultiSelection Box");
-	    editWidget(msb);
+	    auto msb = f->createMultiSelectionBox( widget, "MultiSelection Box" );
+	    editWidget( msb);
 
 	    // edit the item list and update the widget after pressing OK
-	    YPopupInternal::StringArray items(YPopupInternal::editNewStringArray("Items"));
+	    YPopupInternal::StringArray items( YPopupInternal::editNewStringArray( "Items" ) );
 	    // access by reference
-	    for(auto&& str: items) msb->addItem(str);
+	    for ( auto && str: items )
+                msb->addItem(str);
 	}
-	else if (type == "OutputField")
-	    editWidget(f->createOutputField(widget, "Output Field"));
-	else if (type == "Password")
-	    editWidget(f->createPasswordField(widget, "Password"));
-	else if (type == "ProgressBar")
-	    editWidget(f->createProgressBar(widget, "Progress"));
-	else if (type == "PushButton")
-	    editWidget(f->createPushButton(widget, "Button"));
-	else if (type == "RadioButton")
-	    editWidget(f->createRadioButton(widget, "Radio Button"));
-	else if (type == "RadioButtonGroup")
-	    editWidget(f->createRadioButtonGroup(widget));
-	else if (type == "ReplacePoint")
-	    editWidget(f->createReplacePoint(widget));
-	else if (type == "Right")
-	    editWidget(f->createRight(widget));
-	else if (type == "RichText")
-	    editWidget(f->createRichText(widget, "This is a <b>RichText</b>."));
-	else if (type == "SelectionBox")
-	    editWidget(f->createSelectionBox(widget, "Selection Box"));
-	else if (type == "Table")
+	else if ( type == "OutputField" )
+	    editWidget( f->createOutputField( widget, "Output Field" ) );
+	else if ( type == "Password" )
+	    editWidget( f->createPasswordField( widget, "Password" ) );
+	else if ( type == "ProgressBar" )
+	    editWidget( f->createProgressBar( widget, "Progress" ) );
+	else if ( type == "PushButton" )
+	    editWidget( f->createPushButton( widget, "Button" ) );
+	else if ( type == "RadioButton" )
+	    editWidget( f->createRadioButton( widget, "Radio Button" ) );
+	else if ( type == "RadioButtonGroup" )
+	    editWidget( f->createRadioButtonGroup( widget ) );
+	else if ( type == "ReplacePoint" )
+	    editWidget( f->createReplacePoint( widget ) );
+	else if ( type == "Right" )
+	    editWidget( f->createRight( widget ) );
+	else if ( type == "RichText" )
+	    editWidget( f->createRichText( widget, "This is a <b>RichText</b>." ) );
+	else if ( type == "SelectionBox" )
+	    editWidget( f->createSelectionBox( widget, "Selection Box" ) );
+	else if ( type == "Table" )
 	{
-	    YPopupInternal::StringArray items(YPopupInternal::editNewStringArray("Table Columns"));
+	    YPopupInternal::StringArray items( YPopupInternal::editNewStringArray( "Table Columns" ) );
 
 	    // abort adding if Cancel has been pressed
-	    if (!items.empty())
+	    if ( ! items.empty() )
 	    {
 		auto header = new YTableHeader();
 
 		// access by reference
-		for(auto&& str: items) header->addColumn(str);
+		for ( auto && str: items )
+                    header->addColumn(str);
 
-		editWidget(f->createTable(widget, header));
+		editWidget( f->createTable( widget, header ) );
 	    }
 	}
-	else if (type == "Top")
-	    editWidget(f->createTop(widget));
-	else if (type == "Tree")
-	    editWidget(f->createTree(widget, "Tree"));
-	else if (type == "VBox")
-	    editWidget(f->createVBox(widget));
-	else if (type == "VSpacing")
-	    editWidget(f->createVSpacing(widget));
-	else if (type == "VStretch")
-	    editWidget(f->createVStretch(widget));
+	else if ( type == "Top" )
+	    editWidget( f->createTop( widget ) );
+	else if ( type == "Tree" )
+	    editWidget( f->createTree( widget, "Tree" ) );
+	else if ( type == "VBox" )
+	    editWidget( f->createVBox( widget ) );
+	else if ( type == "VSpacing" )
+	    editWidget( f->createVSpacing( widget ) );
+	else if ( type == "VStretch" )
+	    editWidget( f->createVStretch( widget ) );
 	else
 	{
-	    YPopupInternal::message(
-		"Adding \"" + type + "\" widget type is not supported.");
+	    YPopupInternal::message( "Adding \"" + type + "\" widget type is not supported." );
 	    return;
 	}
 
 	targetDialogUpdated();
     }
-    catch( const YUIException & exception )
+    catch ( const YUIException & exception )
     {
-	YPopupInternal::message("Could not add a new widget:\n"
-	    + exception.msg());
+	YPopupInternal::message( "Could not add a new widget:\n" + exception.msg() );
     }
 }
 
@@ -865,7 +912,7 @@ void YDialogSpyPrivate::targetDialogUpdated()
 
     // refresh the spy dialog
     widgetTree->deleteAllItems();
-    fillWidgetTree(targetDialog, widgetTree);
+    fillWidgetTree( targetDialog, widgetTree );
 }
 
 /**
@@ -880,15 +927,16 @@ void YDialogSpyPrivate::refreshButtonStates()
     // a VBox/HBox container, set the labels according to stacking direction.
     if (widget && parent && isBox(parent))
     {
-	upButton->setEnabled(widget != parent->firstChild());
-	upButton->setLabel(isVBox(parent) ? "⬆ Up" : "⬅ Left");
-	downButton->setEnabled(widget != parent->lastChild());
-	downButton->setLabel(isVBox(parent) ? "⬇ Down" : "➡ Right");
+	upButton->setEnabled( widget != parent->firstChild() );
+	upButton->setLabel( isVBox(parent) ? "⬆ Up" : "⬅ Left" );
+
+	downButton->setEnabled( widget != parent->lastChild() );
+	downButton->setLabel( isVBox(parent) ? "⬇ Down" : "➡ Right" );
     }
     else
     {
-	upButton->setEnabled(false);
-	downButton->setEnabled(false);
+	upButton->setEnabled( false );
+	downButton->setEnabled( false );
     }
 
     // TODO: Enable the [Add] menu button only when a widget can be added
@@ -906,13 +954,14 @@ void YDialogSpyPrivate::refreshButtonStates()
  * @param widget   selected widget
  * @param property property name
  */
-void YDialogSpyPrivate::editWidget(YWidget *widget, const string &property)
+void YDialogSpyPrivate::editWidget( YWidget *widget, const string &property )
 {
     // redraw the target dialog
     targetDialog->recalcLayout();
 
-    if (!widget->propertySet().contains(property)) return;
+    if ( ! widget->propertySet().contains(property) )
+        return;
 
-    YPropertyEditor editor(widget);
-    editor.edit(property);
+    YPropertyEditor editor( widget );
+    editor.edit( property );
 }

--- a/libyui/src/YDialogSpy.cc
+++ b/libyui/src/YDialogSpy.cc
@@ -700,7 +700,7 @@ void YDialogSpyPrivate::moveSelected( Direction direction )
 {
     auto target_widget = selectedWidget();
 
-    if ( !target_widget )
+    if ( ! target_widget )
         return;
 
     auto parent = target_widget->parent();


### PR DESCRIPTION
## Description

This cleans up some cruft that has accumulated over the years:

- Removed pointless logging that was good for developing a specific piece of code, but that now just spams the y2log
- Include headers in the new Qt style and consistently: `#include <QFooWidget>` instead of `#include <qfoowidget.h>`
- Follow our C++ coding style
- Don't use cryptic variable names to save typing 2 characters
- Fixed misleading comments or broken English in comments

## Version number? Change log?

None; it will go to OBS with the next PR.