### PR TITLE
CMAKE_INSTALL_LIBDIR with a full path name causes a wrong path for pkgconfig files

### DIFF
--- a/libyui-ncurses/pkgconfig/CMakeLists.txt
+++ b/libyui-ncurses/pkgconfig/CMakeLists.txt
@@ -16,7 +16,7 @@ include( ../../VERSION.cmake )
 include( GNUInstallDirs )       # set CMAKE_INSTALL_LIBDIR
 
 
-set( PKGCONFIG_INSTALL_DIR ${DESTDIR}${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/pkgconfig )
+set( PKGCONFIG_INSTALL_DIR ${DESTDIR}${CMAKE_INSTALL_FULL_LIBDIR}/pkgconfig )
 
 # Generate libyui-ncurses.pc where some CMake variables are expanded from libyui-ncurses.pc.in,
 # but only expand @VARIABLE@, not ${VARIABLE}

--- a/libyui-ncurses/pkgconfig/CMakeLists.txt
+++ b/libyui-ncurses/pkgconfig/CMakeLists.txt
@@ -15,7 +15,15 @@
 include( ../../VERSION.cmake )
 include( GNUInstallDirs )       # set CMAKE_INSTALL_LIBDIR
 
-
+# See https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html
+# CMAKE_INSTALL_FULL_<dir>
+# The absolute path generated from the corresponding CMAKE_INSTALL_<dir> value.
+# If the value is not already an absolute path, an absolute path is constructed
+# typically by prepending the value of the CMAKE_INSTALL_PREFIX variable.
+# So that covers also cmake directive -DCMAKE_INSTALL_LIBDIR=/usr/lib64 with full
+# pathname.
+# CMAKE_INSTALL_FULL_LIBDIR is used to install libyuy-ncurses.pc and inside it
+# to set "libdir" and "plugindir" pkg-config variables
 set( PKGCONFIG_INSTALL_DIR ${DESTDIR}${CMAKE_INSTALL_FULL_LIBDIR}/pkgconfig )
 
 # Generate libyui-ncurses.pc where some CMake variables are expanded from libyui-ncurses.pc.in,

--- a/libyui-ncurses/pkgconfig/libyui-ncurses.pc.in
+++ b/libyui-ncurses/pkgconfig/libyui-ncurses.pc.in
@@ -7,9 +7,9 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
 
-libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
 includedir=${exec_prefix}/include
-plugindir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@/yui
+plugindir=@CMAKE_INSTALL_FULL_LIBDIR@/yui
 
 soversion_major=@SONAME_MAJOR@
 soversion_minor=@SONAME_MINOR@

--- a/libyui-qt/pkgconfig/CMakeLists.txt
+++ b/libyui-qt/pkgconfig/CMakeLists.txt
@@ -15,7 +15,15 @@
 include( ../../VERSION.cmake )
 include( GNUInstallDirs )       # set CMAKE_INSTALL_LIBDIR
 
-
+# See https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html
+# CMAKE_INSTALL_FULL_<dir>
+# The absolute path generated from the corresponding CMAKE_INSTALL_<dir> value.
+# If the value is not already an absolute path, an absolute path is constructed
+# typically by prepending the value of the CMAKE_INSTALL_PREFIX variable.
+# So that covers also cmake directive -DCMAKE_INSTALL_LIBDIR=/usr/lib64 with full
+# pathname.
+# CMAKE_INSTALL_FULL_LIBDIR is used to install libyui-qt.pc and inside it
+# to set "libdir" and "plugindir" pkg-config variables
 set( PKGCONFIG_INSTALL_DIR ${DESTDIR}${CMAKE_INSTALL_FULL_LIBDIR}/pkgconfig )
 
 # Generate libyui-qt.pc where some CMake variables are expanded from libyui-qt.pc.in,

--- a/libyui-qt/pkgconfig/CMakeLists.txt
+++ b/libyui-qt/pkgconfig/CMakeLists.txt
@@ -16,7 +16,7 @@ include( ../../VERSION.cmake )
 include( GNUInstallDirs )       # set CMAKE_INSTALL_LIBDIR
 
 
-set( PKGCONFIG_INSTALL_DIR ${DESTDIR}${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/pkgconfig )
+set( PKGCONFIG_INSTALL_DIR ${DESTDIR}${CMAKE_INSTALL_FULL_LIBDIR}/pkgconfig )
 
 # Generate libyui-qt.pc where some CMake variables are expanded from libyui-qt.pc.in,
 # but only expand @VARIABLE@, not ${VARIABLE}

--- a/libyui-qt/pkgconfig/libyui-qt.pc.in
+++ b/libyui-qt/pkgconfig/libyui-qt.pc.in
@@ -7,9 +7,9 @@
 prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
 
-libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
 includedir=${exec_prefix}/include
-plugindir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@/yui
+plugindir=@CMAKE_INSTALL_FULL_LIBDIR@/yui
 
 soversion_major=@SONAME_MAJOR@
 soversion_minor=@SONAME_MINOR@

--- a/libyui/pkgconfig/CMakeLists.txt
+++ b/libyui/pkgconfig/CMakeLists.txt
@@ -15,7 +15,7 @@ include( ../../VERSION.cmake )
 include( GNUInstallDirs )       # set CMAKE_INSTALL_LIBDIR
 
 
-set( PKGCONFIG_INSTALL_DIR ${DESTDIR}${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/pkgconfig )
+set( PKGCONFIG_INSTALL_DIR ${DESTDIR}${CMAKE_INSTALL_FULL_LIBDIR}/pkgconfig )
 
 # Generate libyui.pc where some CMake variables are expanded from libyui.pc.in,
 # but only expand @VARIABLE@, not ${VARIABLE}

--- a/libyui/pkgconfig/CMakeLists.txt
+++ b/libyui/pkgconfig/CMakeLists.txt
@@ -14,7 +14,15 @@
 include( ../../VERSION.cmake )
 include( GNUInstallDirs )       # set CMAKE_INSTALL_LIBDIR
 
-
+# See https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html
+# CMAKE_INSTALL_FULL_<dir>
+# The absolute path generated from the corresponding CMAKE_INSTALL_<dir> value.
+# If the value is not already an absolute path, an absolute path is constructed
+# typically by prepending the value of the CMAKE_INSTALL_PREFIX variable.
+# So that covers also cmake directive -DCMAKE_INSTALL_LIBDIR=/usr/lib64 with full
+# pathname.
+# CMAKE_INSTALL_FULL_LIBDIR is used to install libyui.pc and inside it
+# to set "libdir" and "plugindir" pkg-config variables
 set( PKGCONFIG_INSTALL_DIR ${DESTDIR}${CMAKE_INSTALL_FULL_LIBDIR}/pkgconfig )
 
 # Generate libyui.pc where some CMake variables are expanded from libyui.pc.in,

--- a/libyui/pkgconfig/libyui.pc.in
+++ b/libyui/pkgconfig/libyui.pc.in
@@ -9,9 +9,9 @@ exec_prefix=${prefix}
 
 datarootdir=${exec_prefix}/share
 datadir=${datarootdir}/libyui
-libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
 includedir=${exec_prefix}/include
-plugindir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@/yui
+plugindir=@CMAKE_INSTALL_FULL_LIBDIR@/yui
 
 soversion_major=@SONAME_MAJOR@
 soversion_minor=@SONAME_MINOR@


### PR DESCRIPTION
Fixed #41