### PR TITLE
Add the default text domain

### DIFF
--- a/libyui-qt/TEXTDOMAIN
+++ b/libyui-qt/TEXTDOMAIN
@@ -1,0 +1,1 @@
+libyui-qt


### PR DESCRIPTION
_**Superseded by https://github.com/libyui/libyui/pull/76**_

(which includes the changes from this PR)

---------------

So the y2makepot script can properly extract the translations from the `*.ui` files.

See related https://github.com/yast/yast-devtools/pull/169