### PR TITLE
CMake: use pkg-config to find and use ncurses libs

### DIFF
--- a/libyui-ncurses/src/CMakeLists.txt
+++ b/libyui-ncurses/src/CMakeLists.txt
@@ -2,16 +2,14 @@
 
 include( ../../VERSION.cmake )
 include( GNUInstallDirs )       # set CMAKE_INSTALL_INCLUDEDIR, ..._LIBDIR
+find_package( PkgConfig REQUIRED )        # pkg_check_modules()
 
 
 # Check if the libs we link against are available.
 # They are all part of package ncurses-devel.
 
-find_library( NCURSESW_LIB NAMES ncursesw REQUIRED )
-find_library( PANELW_LIB   NAMES panelw   REQUIRED )
-find_library( TINFO_LIB    NAMES tinfo    REQUIRED )
 
-set( NCURSES_LIBS ${NCURSESW_LIB} ${PANELW_LIB} ${TINFO_LIB} )
+pkg_check_modules( NCurses REQUIRED IMPORTED_TARGET ncursesw panelw )
 
 
 #
@@ -251,9 +249,9 @@ target_link_directories( ${TARGETLIB} BEFORE PUBLIC ../../libyui/build/src )
 # Libraries that are needed to build this shared lib
 #
 # If in doubt what is really needed, check with "ldd -u" which libs are unused.
-target_link_libraries( ${TARGETLIB}
+target_link_libraries( ${TARGETLIB} PRIVATE
   yui
-  ${NCURSES_LIBS}
+  PkgConfig::NCurses
   )
 
 

--- a/libyui-ncurses/src/NCApplication.cc
+++ b/libyui-ncurses/src/NCApplication.cc
@@ -23,7 +23,7 @@
 
 /-*/
 
-#include <ncursesw/curses.h>
+#include <curses.h>
 
 #define  YUILogComponent "ncurses"
 #include <yui/YUILog.h>

--- a/libyui-ncurses/src/NCstyle.h
+++ b/libyui-ncurses/src/NCstyle.h
@@ -25,7 +25,7 @@
 #ifndef NCstyle_h
 #define NCstyle_h
 
-#include <ncursesw/ncurses.h>
+#include <ncurses.h>
 
 #include <iosfwd>
 #include <string>

--- a/libyui-ncurses/src/NCurses.h
+++ b/libyui-ncurses/src/NCurses.h
@@ -34,7 +34,7 @@
 #include <yui/YWidget.h>
 #include <yui/YMenuItem.h>
 
-#include <ncursesw/curses.h>	/* curses.h: #define  NCURSES_CH_T cchar_t */
+#include <curses.h>	/* curses.h: #define  NCURSES_CH_T cchar_t */
 #include <wchar.h>
 
 #include "ncursesw.h"

--- a/libyui-ncurses/src/ncursesp.h
+++ b/libyui-ncurses/src/ncursesp.h
@@ -28,7 +28,7 @@
 #include <iosfwd>
 
 #include "ncursesw.h"
-#include <ncursesw/panel.h>
+#include <panel.h>
 
 class NCursesPanel : public NCursesWindow
 {

--- a/libyui-ncurses/src/ncursesw.cc
+++ b/libyui-ncurses/src/ncursesw.cc
@@ -47,7 +47,7 @@
 #include <iostream>
 #include <stdlib.h>
 #include <string.h>
-#include <ncursesw/term.h>
+#include <term.h>
 #undef line
 #undef columns
 

--- a/libyui-ncurses/src/ncursesw.h
+++ b/libyui-ncurses/src/ncursesw.h
@@ -27,11 +27,11 @@
 
 #include <iosfwd>
 
-#include <ncursesw/curses.h>
+#include <curses.h>
 #ifndef NCURSES_CXX_IMPEXP
 #define NCURSES_CXX_IMPEXP NCURSES_EXPORT_GENERAL_IMPORT
 #endif
-#include <ncursesw/etip.h>
+#include <etip.h>
 #include <cstdio>
 #include <cstdarg>
 #include <climits>


### PR DESCRIPTION
This could improve build support under other distros like Arch Linux.

By using CMake's pkg-config API to find the `ncurses` lib, we can:

- Make use of the `IMPORTED_TARGET` feature to ensure the target is using the correct library include path.
- We no longer need to specify `ncurses`' dependencies manually (`tinfo`, used by `ncursesw`)

By the way, although CMake itself do have a `FindCurses` which support find `ncurses`, but apparently it won't be able to find the `panelw` component, so this patch uses the pkg-config approach instead.