### PR TITLE
Debugging Support for Patterns in libyui-qt-pkg + Fix for Patterns Category Order

### DIFF
--- a/libyui-qt-pkg/src/YQPkgObjList.h
+++ b/libyui-qt-pkg/src/YQPkgObjList.h
@@ -659,6 +659,7 @@ protected:
      **/
     void setText( int column, const QString & text )
 	  { QTreeWidgetItem::setText( column, text ); }
+
  protected:
     /**
      * Set a column text via Edition.

--- a/libyui-qt-pkg/src/YQPkgPatternList.cc
+++ b/libyui-qt-pkg/src/YQPkgPatternList.cc
@@ -69,6 +69,7 @@ YQPkgPatternList::YQPkgPatternList( QWidget * parent, bool autoFill, bool autoFi
     // is only of little relevance, though.
 
     headers << _( "Pattern" );	_summaryCol	= numCol++;
+    headers << _( "Order" );	_orderCol	= numCol++;
 
     setColumnCount( numCol );
     setHeaderLabels( headers );
@@ -252,6 +253,7 @@ YQPkgPatternList::addPatternItem( ZyppSel	selectable,
 
     resizeColumnToContents( _statusCol  );
     resizeColumnToContents( _summaryCol );
+    resizeColumnToContents( _orderCol   );
 
     addTopLevelItem(item);
     applyExcludeRules( item );
@@ -360,7 +362,7 @@ YQPkgPatternListItem::init()
 	    iconName = "pattern-generic";
 
 	setIcon( _patternList->iconCol(), YQUI::ui()->loadIcon( iconName ) );
-
+        setText( _patternList->orderCol(), fromUTF8( _zyppPattern->order() ) ); 
     }
 
     setStatusIcon();
@@ -506,6 +508,9 @@ YQPkgPatternCategoryItem::addPattern( ZyppPattern pattern )
 	if ( _firstPattern->order().compare( pattern->order() ) < 0 )
 	    _firstPattern = pattern;
     }
+
+    if ( _firstPattern )
+        setText( _patternList->orderCol(), fromUTF8( _firstPattern->order() ) ); 
 }
 
 

--- a/libyui-qt-pkg/src/YQPkgPatternList.h
+++ b/libyui-qt-pkg/src/YQPkgPatternList.h
@@ -236,7 +236,10 @@ protected:
 
     YQPkgPatternList *	_patternList;
     ZyppPattern		_zyppPattern;
-    // cache for total and installed packages
+
+
+    // Cached values
+
     int _total;
     int _installed;
 };

--- a/libyui-qt-pkg/src/YQPkgPatternList.h
+++ b/libyui-qt-pkg/src/YQPkgPatternList.h
@@ -59,6 +59,9 @@ public:
      **/
     virtual ~YQPkgPatternList();
 
+    int orderCol()      const   { return _orderCol; }
+
+
 public slots:
 
     /**
@@ -150,7 +153,7 @@ protected:
     //
 
     QMap<QString, YQPkgPatternCategoryItem*> _categories;
-    int _howmanyCol;
+    int _orderCol;
 };
 
 
@@ -199,6 +202,7 @@ public:
 
     int statusCol()	const	{ return _patternList->statusCol();	}
     int summaryCol()	const	{ return _patternList->summaryCol();	}
+    int orderCol()      const   { return _patternList->orderCol();      }
 
     int totalPackages() const { return _total; }
     int installedPackages() const { return _installed; }

--- a/libyui-qt-pkg/src/YQPkgPatternList.h
+++ b/libyui-qt-pkg/src/YQPkgPatternList.h
@@ -59,7 +59,22 @@ public:
      **/
     virtual ~YQPkgPatternList();
 
+    /**
+     * Column number for the pattern order or -1 if disabled
+     **/
     int orderCol()      const   { return _orderCol; }
+
+    /**
+     * Flag: Should the order column be shown?
+     * (set environment variable Y2_SHOW_PATTERNS_ORDER)
+     **/
+    bool showOrderCol() const   { return _orderCol >= 0; }
+
+    /**
+     * Flag: Show invisible patterns, too?
+     * (set environment variable Y2_SHOW_INVISIBLE_PATTERNS)
+     **/
+    bool showInvisiblePatterns() const { return _showInvisiblePatterns; }
 
 
 public slots:
@@ -153,7 +168,9 @@ protected:
     //
 
     QMap<QString, YQPkgPatternCategoryItem*> _categories;
-    int _orderCol;
+
+    int  _orderCol;
+    bool _showInvisiblePatterns;
 };
 
 


### PR DESCRIPTION
## New List Column "Order" in the "Patterns" List in libyui-qt-pkg

(On request, when the new `Y2_SHOW_PATTERNS_ORDER` environment variable is set)

![fixed-pattern-category-order](https://github.com/libyui/libyui/assets/11538225/8db5add4-581f-4623-a85e-29efeed97069)


## Show Invisible Patterns

(On request, when the new `Y2_SHOW_INVISIBLE_PATTERNS` environment variable is set)

![invisible-patterns](https://github.com/libyui/libyui/assets/11538225/fb6f3816-8e3d-4ec7-ade0-4ec7df81ad65)

## How to Build

- Check out [this branch in the libyui repo](https://github.com/libyui/libyui/tree/huha-debug-pattern-order)

- Prepare a minimalistic build (without NCurses):

      ./build-all -c
      sudo ./build-all -c install

- After any changes to the source:

      cd libyui-qt-pkg/build
      make && sudo make install

## Usage

Set the new `Y2_SHOW_PATTERNS_ORDER` environment variable to get the _Order_ column:

    sudo Y2_SHOW_PATTERNS_ORDER=1 yast2 sw_single


Set the new `Y2_SHOW_INVISIBLE_PATTERNS` environment variable to show also those that are normally not user visible:

    sudo Y2_SHOW_INVISIBLE_PATTERNS=1 yast2 sw_single
