### PR TITLE
Fix incorrect includes for ncurses

### DIFF
--- a/libyui-ncurses/src/NCApplication.cc
+++ b/libyui-ncurses/src/NCApplication.cc
@@ -23,7 +23,7 @@
 
 /-*/
 
-#include <ncursesw/curses.h>
+#include <curses.h>
 
 #define  YUILogComponent "ncurses"
 #include <yui/YUILog.h>

--- a/libyui-ncurses/src/NCstyle.h
+++ b/libyui-ncurses/src/NCstyle.h
@@ -25,7 +25,7 @@
 #ifndef NCstyle_h
 #define NCstyle_h
 
-#include <ncursesw/ncurses.h>
+#include <ncurses.h>
 
 #include <iosfwd>
 #include <string>

--- a/libyui-ncurses/src/NCurses.h
+++ b/libyui-ncurses/src/NCurses.h
@@ -34,7 +34,7 @@
 #include <yui/YWidget.h>
 #include <yui/YMenuItem.h>
 
-#include <ncursesw/curses.h>	/* curses.h: #define  NCURSES_CH_T cchar_t */
+#include <curses.h>	/* curses.h: #define  NCURSES_CH_T cchar_t */
 #include <wchar.h>
 
 #include "ncursesw.h"

--- a/libyui-ncurses/src/ncursesp.h
+++ b/libyui-ncurses/src/ncursesp.h
@@ -28,7 +28,7 @@
 #include <iosfwd>
 
 #include "ncursesw.h"
-#include <ncursesw/panel.h>
+#include <panel.h>
 
 class NCursesPanel : public NCursesWindow
 {

--- a/libyui-ncurses/src/ncursesw.cc
+++ b/libyui-ncurses/src/ncursesw.cc
@@ -47,7 +47,7 @@
 #include <iostream>
 #include <stdlib.h>
 #include <string.h>
-#include <ncursesw/term.h>
+#include <term.h>
 #undef line
 #undef columns
 

--- a/libyui-ncurses/src/ncursesw.h
+++ b/libyui-ncurses/src/ncursesw.h
@@ -27,11 +27,11 @@
 
 #include <iosfwd>
 
-#include <ncursesw/curses.h>
+#include <curses.h>
 #ifndef NCURSES_CXX_IMPEXP
 #define NCURSES_CXX_IMPEXP NCURSES_EXPORT_GENERAL_IMPORT
 #endif
-#include <ncursesw/etip.h>
+#include <etip.h>
 #include <cstdio>
 #include <cstdarg>
 #include <climits>


### PR DESCRIPTION
`pkg-config` already adds the `ncursesw` include path to `CFLAGS`, if needed. `ncurses` must thus be included as

    #include <curses.h>

instead of

    #include <ncursesw/curses.h>

This commit fixes these includes, allowing libyui to be compiled on systems that have `ncurses` headers on `/usr/include` (e.g. Arch Linux).