### PR TITLE
Add gcc-fortran to build requirements (boo#1225861)

### DIFF
--- a/package/libyui.changes
+++ b/package/libyui.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Jul 19 14:45:02 UTC 2024 - Martin Jambor <mjambor@suse.com>
+
+- Add gcc-fortran to build requirements as a work-around to boost
+  now really requiring quadmath.h. (boo#1225861)
+
+-------------------------------------------------------------------
 Tue Jul 16 12:39:55 UTC 2024 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Fix build failure with gcc-14 / C++20: template-id-cdtor error

--- a/package/libyui.spec
+++ b/package/libyui.spec
@@ -28,6 +28,8 @@ Release:        0
 BuildRequires:  boost-devel
 BuildRequires:  cmake >= 3.17
 BuildRequires:  gcc-c++
+# Workaround for boost issue, see boo#1225861
+BuildRequires:  gcc-fortran
 BuildRequires:  libboost_test-devel
 BuildRequires:  pkg-config
 


### PR DESCRIPTION
as a work-around to boost now really requiring quadmath.h.

https://bugzilla.opensuse.org/show_bug.cgi?id=1225861

tl;dr: a bug in boost headers was masked by a matching bug in gcc<=13

Once boost is fixed (expected in boost-1.86) the workaround can be removed.