### PR TITLE
Do not build the qt packages in SLE16 since Qt5 won't be there.

### DIFF
--- a/package/libyui-qt-graph.spec
+++ b/package/libyui-qt-graph.spec
@@ -45,6 +45,10 @@ License:        LGPL-2.1-only OR LGPL-3.0-only
 URL:            http://github.com/libyui/
 Source:         libyui-%{version}.tar.bz2
 
+%if 0%{?suse_version} == 1600 && ! 0%{?is_openSUSE}
+ExclusiveArch: donotbuild
+%endif
+
 %description
 This package contains the Qt graph component for libyui.
 

--- a/package/libyui-qt-pkg.spec
+++ b/package/libyui-qt-pkg.spec
@@ -47,6 +47,10 @@ License:        LGPL-2.1-only OR LGPL-3.0-only
 URL:            https://github.com/libyui/
 Source:         libyui-%{version}.tar.bz2
 
+%if 0%{?suse_version} == 1600 && ! 0%{?is_openSUSE}
+ExclusiveArch: donotbuild
+%endif
+
 %description
 This package contains the Qt package selector component for libyui.
 

--- a/package/libyui-qt-rest-api.spec
+++ b/package/libyui-qt-rest-api.spec
@@ -44,6 +44,10 @@ License:        LGPL-2.1-only OR LGPL-3.0-only
 URL:            http://github.com/libyui/
 Source:         libyui-%{version}.tar.bz2
 
+%if 0%{?suse_version} == 1600 && ! 0%{?is_openSUSE}
+ExclusiveArch: donotbuild
+%endif
+
 %description
 This package provides a libyui REST API plugin for the Qt frontend.
 

--- a/package/libyui-qt.spec
+++ b/package/libyui-qt.spec
@@ -45,6 +45,10 @@ License:        LGPL-2.1-only OR LGPL-3.0-only
 URL:            http://github.com/libyui/
 Source:         libyui-%{version}.tar.bz2
 
+%if 0%{?suse_version} == 1600 && ! 0%{?is_openSUSE}
+ExclusiveArch: donotbuild
+%endif
+
 %description
 This package contains the Qt (graphical) user interface component
 for libyui.

--- a/package/libyui.changes
+++ b/package/libyui.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu May 29 17:22:43 UTC 2025 - Antonio Larrosa <alarrosa@suse.com>
+
+- Do not build the qt packages (libyui-qt, libyui-qt-graph,
+  libyui-qt-pkg and libyui-qt-rest-api) in SLE16 since Qt5 won't
+  be available there.
+
+-------------------------------------------------------------------
 Wed May 28 08:58:26 UTC 2025 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Fix build failure with gcc-15:


### PR DESCRIPTION
Compare with changes and comment from:
https://build.opensuse.org/requests/1281186/changes