### PR TITLE
Change default to switch off Werror

### DIFF
--- a/libyui-ncurses-pkg/CMakeLists.txt
+++ b/libyui-ncurses-pkg/CMakeLists.txt
@@ -24,7 +24,7 @@ project( libyui-ncurses-pkg )
 
 option( BUILD_SRC         "Build in src/ subdirectory"                on )
 option( BUILD_DOC         "Build class documentation"                 off )
-option( WERROR            "Treat all compiler warnings as errors"     on  )
+option( WERROR            "Treat all compiler warnings as errors"     off )
 
 
 #----------------------------------------------------------------------

--- a/libyui-ncurses-rest-api/CMakeLists.txt
+++ b/libyui-ncurses-rest-api/CMakeLists.txt
@@ -24,7 +24,7 @@ project( libyui-ncurses-rest-api )
 
 option( BUILD_SRC         "Build in src/ subdirectory"                on )
 option( BUILD_DOC         "Build class documentation"                 off )
-option( WERROR            "Treat all compiler warnings as errors"     on  )
+option( WERROR            "Treat all compiler warnings as errors"     off )
 
 
 #----------------------------------------------------------------------

--- a/libyui-ncurses/CMakeLists.txt
+++ b/libyui-ncurses/CMakeLists.txt
@@ -25,7 +25,7 @@ project( libyui-ncurses )
 option( BUILD_SRC         "Build in src/ subdirectory"                on )
 option( BUILD_DOC         "Build class documentation"                 off )
 option( BUILD_PKGCONFIG   "Build pkg-config support files"            on  )
-option( WERROR            "Treat all compiler warnings as errors"     on  )
+option( WERROR            "Treat all compiler warnings as errors"     off )
 
 
 #----------------------------------------------------------------------

--- a/libyui-qt-graph/CMakeLists.txt
+++ b/libyui-qt-graph/CMakeLists.txt
@@ -25,7 +25,7 @@ project( libyui-qt-graph )
 option( BUILD_SRC         "Build in src/ subdirectory"                on  )
 option( BUILD_EXAMPLES    "Build C++ -based libyui examples"          off )
 option( BUILD_DOC         "Build class documentation"                 off )
-option( WERROR            "Treat all compiler warnings as errors"     on  )
+option( WERROR            "Treat all compiler warnings as errors"     off )
 
 
 #----------------------------------------------------------------------

--- a/libyui-qt-pkg/CMakeLists.txt
+++ b/libyui-qt-pkg/CMakeLists.txt
@@ -24,7 +24,7 @@ project( libyui-qt-pkg )
 
 option( BUILD_SRC         "Build in src/ subdirectory"                on )
 option( BUILD_DOC         "Build class documentation"                 off )
-option( WERROR            "Treat all compiler warnings as errors"     on  )
+option( WERROR            "Treat all compiler warnings as errors"     off )
 
 
 #----------------------------------------------------------------------

--- a/libyui-qt-rest-api/CMakeLists.txt
+++ b/libyui-qt-rest-api/CMakeLists.txt
@@ -24,7 +24,7 @@ project( libyui-qt-rest-api )
 
 option( BUILD_SRC         "Build in src/ subdirectory"                on )
 option( BUILD_DOC         "Build class documentation"                 off )
-option( WERROR            "Treat all compiler warnings as errors"     on  )
+option( WERROR            "Treat all compiler warnings as errors"     off )
 
 
 #----------------------------------------------------------------------

--- a/libyui-qt/CMakeLists.txt
+++ b/libyui-qt/CMakeLists.txt
@@ -25,7 +25,7 @@ project( libyui-qt )
 option( BUILD_SRC         "Build in src/ subdirectory"                on )
 option( BUILD_DOC         "Build class documentation"                 off )
 option( BUILD_PKGCONFIG   "Build pkg-config support files"            on  )
-option( WERROR            "Treat all compiler warnings as errors"     on  )
+option( WERROR            "Treat all compiler warnings as errors"     off )
 
 
 #----------------------------------------------------------------------

--- a/libyui-qt/src/YQComboBox.cc
+++ b/libyui-qt/src/YQComboBox.cc
@@ -84,8 +84,6 @@ YQComboBox::YQComboBox( YWidget * 	parent,
     // For us, this means a build failure because we always compile with -Werror,
     // promoting all warnings to errors.
     //
-    // Seriously, Trolls, WTF?!?
-    //
     // And now we have to live with ugly stuff like this #if QT_VERSION. Thanks a lot.
     //
     // -- 2020-05-20 HuHa

--- a/libyui/CMakeLists.txt
+++ b/libyui/CMakeLists.txt
@@ -27,7 +27,7 @@ option( BUILD_EXAMPLES    "Build C++ -based libyui examples"          on  )
 option( BUILD_DOC         "Build class documentation"                 off )
 option( BUILD_PKGCONFIG   "Build pkg-config support files"            on  )
 option( LEGACY_BUILDTOOLS "Install legacy cmake buildtools"           on  )
-option( WERROR            "Treat all compiler warnings as errors"     on  )
+option( WERROR            "Treat all compiler warnings as errors"     off )
 
 
 #----------------------------------------------------------------------

--- a/libyui/legacy-buildtools/LibyuiCommon.cmake
+++ b/libyui/legacy-buildtools/LibyuiCommon.cmake
@@ -55,7 +55,7 @@ MACRO( SET_OPTIONS )		# setup configurable options
   OPTION( ENABLE_DEBUG "Shall I include Debug-Symbols in Release?" OFF )
   OPTION( ENABLE_EXAMPLES "Shall I compile the examples, too?" ON )
   OPTION( ENABLE_WALL "Enable the -Wall compiler-flag?" ON )
-  OPTION( ENABLE_WERROR "Enable the -Werror compiler-flag?" ON )
+  OPTION( ENABLE_WERROR "Enable the -Werror compiler-flag?" OFF )
   OPTION( RESPECT_FLAGS "Shall I respect the system c/ldflags?" OFF )
   OPTION( INSTALL_DOCS "Shall \"make install\" install the docs?" OFF )
   OPTION( ENABLE_TESTS "Enable tests?" ON)


### PR DESCRIPTION
Werror requires a very well maintained code base. This is no longer the case for libyui.